### PR TITLE
Used the correct capitalization for callSetName (issue #10).

### DIFF
--- a/src/main/java/com/google/cloud/genomics/dataflow/pipelines/VariantSimilarity.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/pipelines/VariantSimilarity.java
@@ -67,7 +67,7 @@ import java.util.logging.Logger;
  */
 public class VariantSimilarity {
   private static final Logger LOG = Logger.getLogger(VariantSimilarity.class.getName());
-  private static final String VARIANT_FIELDS = "nextPageToken,variants(id,calls(genotype,callsetName))";
+  private static final String VARIANT_FIELDS = "nextPageToken,variants(id,calls(genotype,callSetName))";
 
   private static List<SearchVariantsRequest> getVariantRequests(GenomicsAuth auth, Options options)
       throws IOException, GeneralSecurityException {


### PR DESCRIPTION
The API discovery files for [v1beta](https://www.googleapis.com/discovery/v1/apis/genomics/v1beta/rest) and [v1beta2](https://www.googleapis.com/discovery/v1/apis/genomics/v1beta2/rest) both use `callSetName` as opposed to `callsetName`. I'm not sure which version of the API supports `callsetName`.
