### PR TITLE
Add gVCF to VCF PTransform.

### DIFF
--- a/EclipseCodeFormat.xml
+++ b/EclipseCodeFormat.xml
@@ -1,0 +1,341 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<profiles version="13">
+<profile kind="CodeFormatterProfile" name="Google Genomics Java Code Format" version="13">
+<setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_before_root_tags" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.disabling_tag" value="@formatter:off"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_annotation" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_type_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_arguments" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_anonymous_type_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_case" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_brace_in_array_initializer" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.new_lines_at_block_boundaries" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_cascading_method_invocation_with_arguments.count_dependent" value="16|-1|16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_annotation_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_field" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_while" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.use_on_off_tags" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.wrap_prefer_two_fragments" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_annotation_type_member_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_prefix_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_else_in_if_statement" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.keep_else_statement_on_same_line" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_ellipsis" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.insert_new_line_for_parameter" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.wrap_comment_inline_tags" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_annotation_type_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_breaks_compare_to_cases" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_local_variable_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_multiple_fields" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_parameter" value="1040"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_array_initializer" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_type.count_dependent" value="1585|-1|1585"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_conditional_expression" value="80"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_for" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_multiple_fields.count_dependent" value="16|-1|16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_binary_operator" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_question_in_wildcard" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_array_initializer" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_enum_constant" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_finally_in_try_statement" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_local_variable" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_catch_in_try_statement" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_while" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_after_package" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_qualified_allocation_expression.count_dependent" value="16|4|80"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_method_declaration.count_dependent" value="16|4|48"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_type_parameters" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.continuation_indentation" value="2"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_postfix_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_enum_declaration.count_dependent" value="16|4|49"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_method_invocation" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_superinterfaces" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_new_chunk" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_binary_operator" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_package" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_cascading_method_invocation_with_arguments" value="16"/>
+<setting id="org.eclipse.jdt.core.compiler.source" value="1.8"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_constructor_declaration.count_dependent" value="16|4|48"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_constant_arguments" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_constructor_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_line_comments" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_enum_declarations" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.join_wrapped_lines" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_block" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_explicit_constructor_call" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.wrap_non_simple_local_variable_annotation" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_invocation_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.align_type_members_on_columns" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_member_type" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_enum_constant" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_enum_constants.count_dependent" value="16|5|48"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_for" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_method_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_selector_in_method_invocation" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_switch" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_unary_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_case" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.indent_parameter_description" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_lambda_arrow" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_switch" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_block_comment" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_type_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.lineSplit" value="100"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_if" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_selector_in_method_invocation.count_dependent" value="16|4|48"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_brackets_in_array_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_parenthesized_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_explicitconstructorcall_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_constructor_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_first_class_body_declaration" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_method" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indentation.size" value="4"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.enabling_tag" value="@formatter:on"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_enum_constant" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_package" value="1585"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_superclass_in_type_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_assignment" value="16"/>
+<setting id="org.eclipse.jdt.core.compiler.problem.assertIdentifier" value="error"/>
+<setting id="org.eclipse.jdt.core.formatter.tabulation.char" value="space"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_semicolon_in_try_resources" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_parameters" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_prefix_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_body" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_method" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.wrap_outer_expressions_when_nested" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.wrap_non_simple_type_annotation" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.format_guardian_clause_on_one_line" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_for" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_field_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_cast" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_constructor_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_labeled_statement" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_annotation_type_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_method_body" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_method_declaration" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_try" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_method_invocation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_allocation_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_enum_constant" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_at_in_annotation_type_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_throws" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_if" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_switch" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_throws" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_return" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_question_in_wildcard" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_question_in_conditional" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_try" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_allocation_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.preserve_white_space_between_code_and_line_comments" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_parenthesized_expression_in_throw" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_type_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.compiler.problem.enumIdentifier" value="error"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_generic_type_arguments" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_switch" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.comment_new_line_at_start_of_html_paragraph" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_ellipsis" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_block" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comment_prefix" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_inits" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_method_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.compact_else_if" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.wrap_non_simple_parameter_annotation" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.wrap_before_or_operator_multicatch" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_array_initializer" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_increments" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_method" value="1585"/>
+<setting id="org.eclipse.jdt.core.formatter.format_line_comment_starting_on_first_column" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_bracket_in_array_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_field" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.indent_root_tags" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_constant" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_declarations" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_union_type_in_multicatch" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_explicitconstructorcall_arguments" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_switch" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_method_declaration_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_superinterfaces" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_allocation_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.tabulation.size" value="2"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_opening_brace_in_array_initializer" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_brace_in_block" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_enum_constant" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_constructor_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_throws" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_if" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_method_invocation.count_dependent" value="16|5|80"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.clear_blank_lines_in_javadoc_comment" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_parameter.count_dependent" value="1040|-1|1040"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_constructor_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_assignment_operator" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_assignment_operator" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_package.count_dependent" value="1585|-1|1585"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_empty_lines" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_synchronized" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_paren_in_cast" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_declaration_parameters" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.force_if_else_statement_brace" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_block_in_case" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.number_of_empty_lines_to_preserve" value="3"/>
+<setting id="org.eclipse.jdt.core.formatter.wrap_non_simple_package_annotation" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_catch" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_constructor_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_method_invocation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_bracket_in_array_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_qualified_allocation_expression" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_annotation.count_dependent" value="16|-1|16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_and_in_type_parameter" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_type" value="1585"/>
+<setting id="org.eclipse.jdt.core.compiler.compliance" value="1.8"/>
+<setting id="org.eclipse.jdt.core.formatter.continuation_indentation_for_array_initializer" value="2"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_brackets_in_array_allocation_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_at_in_annotation_type_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_lambda_body" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_allocation_expression" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_cast" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_unary_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_new_anonymous_class" value="20"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_local_variable.count_dependent" value="1585|-1|1585"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_anonymous_type_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.keep_empty_array_initializer_on_one_line" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_enum_declaration" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_type_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_field.count_dependent" value="1585|-1|1585"/>
+<setting id="org.eclipse.jdt.core.formatter.keep_imple_if_on_one_line" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_constructor_declaration_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_closing_angle_bracket_in_type_parameters" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_labeled_statement" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_at_end_of_file_if_missing" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_for" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_parameterized_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_constructor_declaration.count_dependent" value="16|5|80"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_type_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_enum_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_binary_expression" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_while" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_type" value="insert"/>
+<setting id="org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode" value="enabled"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_try" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.put_empty_statement_on_new_line" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_label" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_parameter" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_type_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_method_invocation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_javadoc_comments" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_enum_constant" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_before_while_in_do_statement" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_enum_constant.count_dependent" value="16|-1|16"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.line_length" value="100"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_after_annotation_on_package" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_between_import_groups" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_enum_constant_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_constructor_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.number_of_blank_lines_at_beginning_of_method_body" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_conditional" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_type_header" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_annotation_type_member_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.wrap_before_binary_operator" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_between_type_declarations" value="2"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_declaration_header" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_synchronized" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_enum_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_statements_compare_to_block" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.join_lines_in_comments" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_question_in_conditional" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_field_declarations" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_compact_if" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_for_inits" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_switchstatements_compare_to_cases" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_array_initializer" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_default" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_and_in_type_parameter" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_parens_in_constructor_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_before_imports" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_assert" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_field" value="1585"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_html" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_throws_clause_in_method_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_angle_bracket_in_type_parameters" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_bracket_in_array_allocation_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_anonymous_type_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_colon_in_conditional" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_for" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_expressions_in_array_initializer.count_dependent" value="16|5|80"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_postfix_operator" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_source_code" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_synchronized" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_allocation_expression" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_constructor_declaration_throws" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_method_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_brace_in_array_initializer" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.compiler.codegen.targetPlatform" value="1.8"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_resources_in_try" value="80"/>
+<setting id="org.eclipse.jdt.core.formatter.use_tabs_only_for_leading_indentations" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_annotation" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_header" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.format_block_comments" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_enum_constant" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_enum_constants" value="0"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_lambda_arrow" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_parenthesized_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_annotation_declaration_header" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_new_line_in_empty_block" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_parenthesized_expression" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_catch" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_multiple_local_declarations" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_superinterfaces_in_type_declaration.count_dependent" value="16|4|48"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_switch" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_comma_in_for_increments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_method.count_dependent" value="1585|-1|1585"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_invocation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_colon_in_assert" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.brace_position_for_type_declaration" value="end_of_line"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_brace_in_array_initializer" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_between_empty_braces_in_array_initializer" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_binary_expression.count_dependent" value="16|-1|16"/>
+<setting id="org.eclipse.jdt.core.formatter.wrap_non_simple_member_annotation" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_annotations_on_local_variable" value="1585"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_opening_paren_in_method_declaration" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon_in_for" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_explicit_constructor_call.count_dependent" value="16|5|80"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_paren_in_catch" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_parameterized_type_reference" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_field_declarations" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_closing_paren_in_annotation" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_generic_type_arguments.count_dependent" value="16|-1|16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_parameterized_type_reference" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_arguments_in_allocation_expression.count_dependent" value="16|5|80"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_method_invocation_arguments" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_method_declaration.count_dependent" value="16|5|80"/>
+<setting id="org.eclipse.jdt.core.formatter.comment.new_lines_at_javadoc_boundaries" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.blank_lines_after_imports" value="1"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_comma_in_multiple_local_declarations" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.indent_body_declarations_compare_to_enum_constant_header" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_after_semicolon_in_for" value="insert"/>
+<setting id="org.eclipse.jdt.core.formatter.never_indent_line_comments_on_first_column" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_semicolon_in_try_resources" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_for_statement" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.insert_space_before_opening_angle_bracket_in_type_arguments" value="do not insert"/>
+<setting id="org.eclipse.jdt.core.formatter.never_indent_block_comments_on_first_column" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.keep_then_statement_on_same_line" value="false"/>
+</profile>
+</profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <groupId>com.google.cloud.genomics</groupId>
   <artifactId>google-genomics-dataflow</artifactId>
   <packaging>jar</packaging>
-  <version>v1beta2-0.2-SNAPSHOT</version>
+  <version>v1beta2-0.20-SNAPSHOT</version>
 
   <organization>
     <name>Google</name>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <groupId>com.google.cloud.genomics</groupId>
   <artifactId>google-genomics-dataflow</artifactId>
   <packaging>jar</packaging>
-  <version>v1beta2-0.20-SNAPSHOT</version>
+  <version>v1beta2-0.2-SNAPSHOT</version>
 
   <organization>
     <name>Google</name>

--- a/pom.xml
+++ b/pom.xml
@@ -173,6 +173,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-all</artifactId>
+      <version>1.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.mortbay.jetty</groupId>
       <artifactId>jetty</artifactId>
       <version>${jetty.version}</version>

--- a/results/ibs/1000Genomes-chr22/analyze-ibs-data.Rmd
+++ b/results/ibs/1000Genomes-chr22/analyze-ibs-data.Rmd
@@ -22,7 +22,7 @@ Genomics Public Data](https://cloud.google.com/genomics/data/1000-genomes).
 ```{r echo=FALSE, eval=FALSE}
 # This codelab assumes that the current working directory is where the Rmd file
 # resides
-setwd("/YOUR/PATH/TO//1000Genomes-chr22/ibs")
+setwd("/YOUR/PATH/TO/1000Genomes-chr22/ibs")
 ```
 
 ## Computing IBS
@@ -108,8 +108,12 @@ ibsPlinkSeqData <- melt(data.matrix(ibsPlinkSeqData))
 Set the column names of the two sets of IBS data consistently.
 
 ```{r message=FALSE, comment=NA}
-ColumnNames <- function(ibsData) {
-  colnames(ibsData) <- c("sample1", "sample2", "ibsScore")
+ColumnNames <- function(ibsData) { 
+  if(3 == ncol(ibsData)) {
+    colnames(ibsData) <- c("sample1", "sample2", "ibsScore")
+  } else {
+    colnames(ibsData) <- c("sample1", "sample2", "ibsScore", "similar", "observed")
+  }
 }
 colnames(ibsDataflowData) <- ColumnNames(ibsDataflowData)
 colnames(ibsPlinkSeqData) <- ColumnNames(ibsPlinkSeqData)
@@ -122,7 +126,7 @@ MakeIBSDataSymmetric <- function(ibsData) {
   ibsPairsMirrored <- data.frame(sample1=ibsData$sample2,
                                  sample2=ibsData$sample1,
                                  ibsScore=ibsData$ibsScore)
-  ibsData <- rbind(ibsData, ibsPairsMirrored)
+  ibsData <- rbind(ibsData[,1:3], ibsPairsMirrored)
 }
 ibsDataflowData <- MakeIBSDataSymmetric(ibsDataflowData)
 ```

--- a/results/ibs/1000Genomes-chr22/analyze-ibs-data.md
+++ b/results/ibs/1000Genomes-chr22/analyze-ibs-data.md
@@ -109,8 +109,12 @@ Set the column names of the two sets of IBS data consistently.
 
 
 ```r
-ColumnNames <- function(ibsData) {
-  colnames(ibsData) <- c("sample1", "sample2", "ibsScore")
+ColumnNames <- function(ibsData) { 
+  if(3 == ncol(ibsData)) {
+    colnames(ibsData) <- c("sample1", "sample2", "ibsScore")
+  } else {
+    colnames(ibsData) <- c("sample1", "sample2", "ibsScore", "similar", "observed")
+  }
 }
 colnames(ibsDataflowData) <- ColumnNames(ibsDataflowData)
 colnames(ibsPlinkSeqData) <- ColumnNames(ibsPlinkSeqData)
@@ -124,7 +128,7 @@ MakeIBSDataSymmetric <- function(ibsData) {
   ibsPairsMirrored <- data.frame(sample1=ibsData$sample2,
                                  sample2=ibsData$sample1,
                                  ibsScore=ibsData$ibsScore)
-  ibsData <- rbind(ibsData, ibsPairsMirrored)
+  ibsData <- rbind(ibsData[,1:3], ibsPairsMirrored)
 }
 ibsDataflowData <- MakeIBSDataSymmetric(ibsDataflowData)
 ```

--- a/src/main/java/com/google/cloud/genomics/dataflow/functions/AlleleSimilarityCalculator.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/functions/AlleleSimilarityCalculator.java
@@ -58,7 +58,7 @@ public class AlleleSimilarityCalculator extends
     CallSimilarityCalculator callSimilarityCalculator =
         callSimilarityCalculatorFactory.get(isReferenceMajor(variant));
     FluentIterable<KV<Call, Call>> pairs =
-        PairGenerator.<Call, ImmutableList<Call>>allPairs(getSamplesWithVariant(variant));
+        PairGenerator.<Call, ImmutableList<Call>>allPairs(getSamplesWithVariant(variant), false);
     for (KV<Call, Call> pair : pairs) {
       accumulateCallSimilarity(callSimilarityCalculator, pair.getKey(), pair.getValue());
     }
@@ -97,7 +97,7 @@ public class AlleleSimilarityCalculator extends
       for (Integer i : call.getGenotype()) {
         if (i == 0) {
           ++referenceAlleles;
-        } else {
+        } else if (i > 0) {
           ++alternateAlleles;
         }
       }

--- a/src/main/java/com/google/cloud/genomics/dataflow/functions/ExtractSimilarCallsets.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/functions/ExtractSimilarCallsets.java
@@ -1,16 +1,14 @@
 /*
  * Copyright (C) 2014 Google Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
- *
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
  * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
 package com.google.cloud.genomics.dataflow.functions;
@@ -21,7 +19,6 @@ import com.google.cloud.dataflow.sdk.transforms.DoFn;
 import com.google.cloud.dataflow.sdk.values.KV;
 import com.google.cloud.genomics.dataflow.utils.CallFilters;
 import com.google.cloud.genomics.dataflow.utils.PairGenerator;
-import com.google.cloud.genomics.dataflow.utils.VariantUtils;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
@@ -43,8 +40,8 @@ public class ExtractSimilarCallsets extends DoFn<Variant, KV<KV<String, String>,
 
   @Override
   public void processElement(ProcessContext context) {
-    for (KV<String, String> pair : PairGenerator.<String, ImmutableList<String>>allPairs(
-        getSamplesWithVariant(context.element()), true, String.CASE_INSENSITIVE_ORDER)) {
+    for (KV<String, String> pair : PairGenerator.WITH_REPLACEMENT.allPairs(
+        getSamplesWithVariant(context.element()), String.CASE_INSENSITIVE_ORDER)) {
       accumulator.add(pair);
     }
   }

--- a/src/main/java/com/google/cloud/genomics/dataflow/functions/ExtractSimilarCallsets.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/functions/ExtractSimilarCallsets.java
@@ -43,7 +43,7 @@ public class ExtractSimilarCallsets extends DoFn<Variant, KV<KV<String, String>,
   @Override
   public void processElement(ProcessContext context) {
     for (KV<String, String> pair : PairGenerator.<String, ImmutableList<String>>allPairs(
-        getSamplesWithVariant(context.element()))) {
+        getSamplesWithVariant(context.element()), true)) {
       accumulator.add(pair);
     }
   }

--- a/src/main/java/com/google/cloud/genomics/dataflow/functions/ExtractSimilarCallsets.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/functions/ExtractSimilarCallsets.java
@@ -21,6 +21,7 @@ import com.google.cloud.dataflow.sdk.transforms.DoFn;
 import com.google.cloud.dataflow.sdk.values.KV;
 import com.google.cloud.genomics.dataflow.utils.CallFilters;
 import com.google.cloud.genomics.dataflow.utils.PairGenerator;
+import com.google.cloud.genomics.dataflow.utils.VariantUtils;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
@@ -43,7 +44,7 @@ public class ExtractSimilarCallsets extends DoFn<Variant, KV<KV<String, String>,
   @Override
   public void processElement(ProcessContext context) {
     for (KV<String, String> pair : PairGenerator.<String, ImmutableList<String>>allPairs(
-        getSamplesWithVariant(context.element()), true)) {
+        getSamplesWithVariant(context.element()), true, String.CASE_INSENSITIVE_ORDER)) {
       accumulator.add(pair);
     }
   }

--- a/src/main/java/com/google/cloud/genomics/dataflow/functions/FormatIBSData.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/functions/FormatIBSData.java
@@ -1,23 +1,22 @@
 /*
-Copyright 2014 Google Inc. All rights reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+ * Copyright 2014 Google Inc. All rights reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 
 package com.google.cloud.genomics.dataflow.functions;
 
 import com.google.cloud.dataflow.sdk.transforms.DoFn;
 import com.google.cloud.dataflow.sdk.values.KV;
+import com.google.common.base.Joiner;
 
 /**
  * Computes the IBS score based on the given sums of ratios and numbers of shared alleles. Then, it
@@ -31,6 +30,7 @@ public final class FormatIBSData extends DoFn<KV<KV<String, String>, KV<Double, 
     String call2 = result.getKey().getValue();
     Double sumOfRatios = result.getValue().getKey();
     int numberOfRatios = result.getValue().getValue();
-    c.output(call1 + "\t" + call2 + "\t" + sumOfRatios / numberOfRatios + "\t" + sumOfRatios + "\t" + numberOfRatios);
+    c.output(Joiner.on('\t').join(call1, call2, sumOfRatios / numberOfRatios, sumOfRatios,
+        numberOfRatios));
   }
 }

--- a/src/main/java/com/google/cloud/genomics/dataflow/functions/FormatIBSData.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/functions/FormatIBSData.java
@@ -31,6 +31,6 @@ public final class FormatIBSData extends DoFn<KV<KV<String, String>, KV<Double, 
     String call2 = result.getKey().getValue();
     Double sumOfRatios = result.getValue().getKey();
     int numberOfRatios = result.getValue().getValue();
-    c.output(call1 + "\t" + call2 + "\t" + sumOfRatios / numberOfRatios);
+    c.output(call1 + "\t" + call2 + "\t" + sumOfRatios / numberOfRatios + "\t" + sumOfRatios + "\t" + numberOfRatios);
   }
 }

--- a/src/main/java/com/google/cloud/genomics/dataflow/functions/JoinGvcfVariants.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/functions/JoinGvcfVariants.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (C) 2015 Google Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.genomics.dataflow.functions;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+
+import com.google.api.client.util.Lists;
+import com.google.api.services.genomics.model.Variant;
+import com.google.cloud.dataflow.sdk.transforms.DoFn;
+import com.google.cloud.dataflow.sdk.values.KV;
+import com.google.cloud.genomics.dataflow.utils.GenomicsDatasetOptions;
+import com.google.cloud.genomics.dataflow.utils.VariantUtils;
+
+/**
+ * The transforms in this class convert data in Genome VCF (gVCF) format to variant-only VCF data
+ * with calls from block-records merged into the variants with which they overlap.  
+ * 
+ * This is currently done only for SNP variants.  Indels and structural variants are left as-is.
+ */
+public class JoinGvcfVariants {
+
+  @SuppressWarnings("serial")
+  public static class BinVariants extends DoFn<Variant, KV<KV<String, Integer>, Variant>> {
+
+    public int getStartBin(int binSize, Variant variant) {
+      // Round down to the nearest integer
+      return (int) (variant.getStart() / binSize);
+    }
+
+    public int getEndBin(int binSize, Variant variant) {
+      // Round down to the nearest integer
+      return (int) (variant.getEnd() / binSize);
+    }
+
+    @Override
+    public void processElement(ProcessContext context) {
+      GenomicsDatasetOptions options =
+          context.getPipelineOptions().as(GenomicsDatasetOptions.class);
+      Variant variant = context.element();
+      int startBin = getStartBin(options.getBinSize(), variant);
+      int endBin =
+          VariantUtils.isVariant(variant) ? startBin : getEndBin(options.getBinSize(), variant);
+      for (int bin = startBin; bin <= endBin; bin++) {
+        context.output(KV.of(KV.of(variant.getReferenceName(), bin), variant));
+      }
+    }
+  }
+
+  @SuppressWarnings("serial")
+  public static class MergeVariants extends
+      DoFn<KV<KV<String, Integer>, Iterable<Variant>>, Variant> {
+
+    @Override
+    public void processElement(ProcessContext context) {
+
+      // The upper bound on number of variants in the iterable is dependent upon the binSize
+      // used in the prior step to construct the key.
+      KV<KV<String, Integer>, Iterable<Variant>> kv = context.element();
+
+      // Sort by start position descending and ensure that if a variant
+      // and a ref-matching block are at the same position, the
+      // ref-matching block comes first.
+      List<Variant> records = Lists.newArrayList(kv.getValue());
+      Collections.sort(records, new JoinGvcfVariants.VariantComparator());
+
+      // The upper bound on potential overlaps is the sample size plus the number of
+      // block records that occur between actual variants.
+      List<Variant> blockRecords = new ArrayList<Variant>();
+
+      for (Variant record : records) {
+        if (VariantUtils.isVariant(record)) {
+          // TODO: determine and implement the correct criteria for overlaps of non-SNP variants
+          if (VariantUtils.isSnp(record)) {
+            for (Iterator<Variant> iterator = blockRecords.iterator(); iterator.hasNext();) {
+              Variant blockRecord = iterator.next();
+              if (JoinGvcfVariants.isOverlapping(blockRecord, record)) {
+                record.getCalls().addAll(blockRecord.getCalls());
+              } else {
+                // Remove the current element from the iterator and the list since it is
+                // left of the genomic region we are currently working on due to our sort..
+                iterator.remove();
+              }
+            }
+          }
+          context.output(record);
+        } else {
+          blockRecords.add(record);
+        }
+      }
+    }
+  }
+
+  /**
+   * Comparator for sorting variants by genomic position and alternateBases
+   */
+  public static class VariantComparator implements Comparator<Variant> {
+    @Override
+    public int compare(Variant v1, Variant v2) {
+
+      int startComparison = v1.getStart().compareTo(v2.getStart());
+      if (0 != startComparison) {
+        return startComparison;
+      }
+
+      if (null == v1.getAlternateBases()) {
+        return -1;
+      } else if (null == v2.getAlternateBases()) {
+        return 1;
+      }
+      return 0;
+    }
+  }
+
+  public static boolean isOverlapping(Variant blockRecord, Variant variant) {
+    if (blockRecord.getStart() <= variant.getStart()
+        && blockRecord.getEnd() >= variant.getStart() + 1) {
+      return true;
+    }
+    return false;
+  }
+}

--- a/src/main/java/com/google/cloud/genomics/dataflow/pipelines/IdentityByState.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/pipelines/IdentityByState.java
@@ -1,31 +1,36 @@
 /*
  * Copyright (C) 2014 Google Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
- *
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
  * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
 package com.google.cloud.genomics.dataflow.pipelines;
 
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.List;
+
 import com.google.api.services.genomics.model.SearchVariantsRequest;
+import com.google.api.services.genomics.model.Variant;
 import com.google.cloud.dataflow.sdk.Pipeline;
 import com.google.cloud.dataflow.sdk.io.TextIO;
 import com.google.cloud.dataflow.sdk.options.PipelineOptionsFactory;
 import com.google.cloud.dataflow.sdk.transforms.Combine;
 import com.google.cloud.dataflow.sdk.transforms.ParDo;
 import com.google.cloud.dataflow.sdk.values.KV;
+import com.google.cloud.dataflow.sdk.values.PCollection;
 import com.google.cloud.genomics.dataflow.functions.AlleleSimilarityCalculator;
 import com.google.cloud.genomics.dataflow.functions.CallSimilarityCalculatorFactory;
 import com.google.cloud.genomics.dataflow.functions.FormatIBSData;
 import com.google.cloud.genomics.dataflow.functions.IBSCalculator;
+import com.google.cloud.genomics.dataflow.functions.JoinGvcfVariants;
 import com.google.cloud.genomics.dataflow.readers.VariantReader;
 import com.google.cloud.genomics.dataflow.utils.DataflowWorkarounds;
 import com.google.cloud.genomics.dataflow.utils.GenomicsDatasetOptions;
@@ -33,23 +38,22 @@ import com.google.cloud.genomics.dataflow.utils.GenomicsOptions;
 import com.google.cloud.genomics.dataflow.utils.IdentityByStateOptions;
 import com.google.cloud.genomics.utils.GenomicsFactory;
 
-import java.io.IOException;
-import java.security.GeneralSecurityException;
-import java.util.List;
-
 /**
  * A pipeline that computes Identity by State (IBS) for each pair of individuals in a dataset.
  *
  * See the README for running instructions.
  */
+
 public class IdentityByState {
-  private static final String VARIANT_FIELDS = "nextPageToken,variants(id,calls(genotype,callSetName))";
+  private static final String VARIANT_FIELDS =
+      "nextPageToken,variants(id,calls(genotype,callSetName))";
 
   public static void main(String[] args) throws IOException, GeneralSecurityException,
       InstantiationException, IllegalAccessException {
-    IdentityByStateOptions options = PipelineOptionsFactory.fromArgs(args)
-        .withValidation().as(IdentityByStateOptions.class);
+    IdentityByStateOptions options =
+        PipelineOptionsFactory.fromArgs(args).withValidation().as(IdentityByStateOptions.class);
     GenomicsOptions.Methods.validateOptions(options);
+    GenomicsDatasetOptions.Methods.validateOptions(options);
 
     GenomicsFactory.OfflineAuth auth = GenomicsOptions.Methods.getGenomicsAuth(options);
     List<SearchVariantsRequest> requests =
@@ -57,11 +61,24 @@ public class IdentityByState {
 
     Pipeline p = Pipeline.create(options);
     DataflowWorkarounds.registerGenomicsCoders(p);
-    DataflowWorkarounds
-        .getPCollection(requests, p, options.getNumWorkers())
-        .apply(
-            ParDo.named(VariantReader.class.getSimpleName()).of(
-                new VariantReader(auth, VARIANT_FIELDS)))
+    PCollection<SearchVariantsRequest> input =
+        DataflowWorkarounds.getPCollection(requests, p, options.getNumWorkers());
+
+    PCollection<Variant> variants;
+    if (options.getIsGvcf()) {
+      // Special handling is needed for data in gVCF format since IBS must take into account
+      // reference-matches in addition to the variants (unlike
+      // other analyses such as PCA).
+      variants =
+          JoinGvcfVariants.joinGvcfVariantsTransform(input, auth,
+              JoinGvcfVariants.GVCF_VARIANT_FIELDS);
+    } else {
+      variants =
+          input.apply(ParDo.named(VariantReader.class.getSimpleName()).of(
+              new VariantReader(auth, VARIANT_FIELDS)));
+    }
+
+    variants
         .apply(
             ParDo.named(AlleleSimilarityCalculator.class.getSimpleName()).of(
                 new AlleleSimilarityCalculator(getCallSimilarityCalculatorFactory(options))))

--- a/src/main/java/com/google/cloud/genomics/dataflow/utils/GenomicsDatasetOptions.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/utils/GenomicsDatasetOptions.java
@@ -49,7 +49,7 @@ public interface GenomicsDatasetOptions extends GenomicsOptions {
 
       List<SearchVariantsRequest> requests = Lists.newArrayList();
       for (Contig contig : contigs) {
-        for (Contig shard : contig.getShards()) {
+        for (Contig shard : contig.getShards(options.getBasesPerShard())) {
           LOG.info("Adding request with " + shard.referenceName + " " + shard.start + " to "
               + shard.end);
           requests.add(shard.getVariantsRequest(datasetId));
@@ -87,6 +87,12 @@ public interface GenomicsDatasetOptions extends GenomicsOptions {
   String getReferences();
 
   void setReferences(String references);
+
+  @Description("The maximum number of bases per shard.")
+  @Default.Long(Contig.DEFAULT_NUMBER_OF_BASES_PER_SHARD)
+  long getBasesPerShard();
+
+  void setBasesPerShard(long basesPerShard);
 
   @Description("If querying a dataset in Genome VCF (gVCF) format, specify this "
       + "flag so that the pipeline correctly takes into account reference-matching "

--- a/src/main/java/com/google/cloud/genomics/dataflow/utils/GenomicsDatasetOptions.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/utils/GenomicsDatasetOptions.java
@@ -19,6 +19,7 @@ import com.google.cloud.dataflow.sdk.options.Default;
 import com.google.cloud.dataflow.sdk.options.Description;
 import com.google.cloud.genomics.utils.Contig;
 import com.google.cloud.genomics.utils.GenomicsFactory;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 
 import java.io.IOException;
@@ -58,10 +59,7 @@ public interface GenomicsDatasetOptions extends GenomicsOptions {
     }
 
     public static void validateOptions(GenomicsDatasetOptions options) {
-      int binSize = options.getBinSize();
-      if (binSize <= 0) {
-        throw new IllegalArgumentException("binSize must be greater than zero");
-      }
+      Preconditions.checkState(0 < options.getBinSize(), "binSize must be greater than zero");
     }
 
   }

--- a/src/main/java/com/google/cloud/genomics/dataflow/utils/GenomicsDatasetOptions.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/utils/GenomicsDatasetOptions.java
@@ -1,11 +1,11 @@
 /*
  * Copyright (C) 2014 Google Inc.
- *
+ * 
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
- *
+ * 
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -37,14 +37,14 @@ public interface GenomicsDatasetOptions extends GenomicsOptions {
 
     // TODO: If needed, add getReadRequests method
     public static List<SearchVariantsRequest> getVariantRequests(GenomicsDatasetOptions options,
-        GenomicsFactory.OfflineAuth auth, boolean excludeXY)
-        throws IOException, GeneralSecurityException {
+        GenomicsFactory.OfflineAuth auth, boolean excludeXY) throws IOException,
+        GeneralSecurityException {
       String datasetId = options.getDatasetId();
       Genomics genomics = auth.getGenomics(auth.getDefaultFactory());
 
-      Iterable<Contig> contigs = options.isAllContigs()
-          ? Contig.getContigsInVariantSet(genomics, datasetId, excludeXY)
-          : Contig.parseContigsFromCommandLine(options.getReferences());
+      Iterable<Contig> contigs =
+          options.isAllContigs() ? Contig.getContigsInVariantSet(genomics, datasetId, excludeXY)
+              : Contig.parseContigsFromCommandLine(options.getReferences());
 
       List<SearchVariantsRequest> requests = Lists.newArrayList();
       for (Contig contig : contigs) {
@@ -56,6 +56,14 @@ public interface GenomicsDatasetOptions extends GenomicsOptions {
       }
       return requests;
     }
+
+    public static void validateOptions(GenomicsDatasetOptions options) {
+      int binSize = options.getBinSize();
+      if (binSize <= 0) {
+        throw new IllegalArgumentException("binSize must be greater than zero");
+      }
+    }
+
   }
 
   @Description("The ID of the Google Genomics dataset this pipeline is working with. "
@@ -81,4 +89,18 @@ public interface GenomicsDatasetOptions extends GenomicsOptions {
   String getReferences();
 
   void setReferences(String references);
+
+  @Description("If querying a dataset in Genome VCF (gVCF) format, specify this "
+      + "flag so that the pipeline correctly takes into account reference-matching "
+      + "block records which overlap variants within the dataset.")
+  @Default.Boolean(false)
+  boolean getIsGvcf();
+
+  void setIsGvcf(boolean isGvcf);
+
+  @Description("Genomic window \"bin\" size to use for gVCF data when joining block-records with variants.")
+  @Default.Integer(1000)
+  int getBinSize();
+
+  void setBinSize(int binSize);
 }

--- a/src/main/java/com/google/cloud/genomics/dataflow/utils/GenomicsDatasetOptions.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/utils/GenomicsDatasetOptions.java
@@ -13,6 +13,11 @@
  */
 package com.google.cloud.genomics.dataflow.utils;
 
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.List;
+import java.util.logging.Logger;
+
 import com.google.api.services.genomics.Genomics;
 import com.google.api.services.genomics.model.SearchVariantsRequest;
 import com.google.cloud.dataflow.sdk.options.Default;
@@ -21,11 +26,6 @@ import com.google.cloud.genomics.utils.Contig;
 import com.google.cloud.genomics.utils.GenomicsFactory;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
-
-import java.io.IOException;
-import java.security.GeneralSecurityException;
-import java.util.List;
-import java.util.logging.Logger;
 
 /**
  * A common options class for all pipelines that operate over a single dataset and write their
@@ -59,7 +59,8 @@ public interface GenomicsDatasetOptions extends GenomicsOptions {
     }
 
     public static void validateOptions(GenomicsDatasetOptions options) {
-      Preconditions.checkState(0 < options.getBinSize(), "binSize must be greater than zero");
+      Preconditions.checkArgument(0 < options.getBinSize(), "binSize must be greater than zero");
+      GenomicsOptions.Methods.validateOptions(options);
     }
 
   }

--- a/src/main/java/com/google/cloud/genomics/dataflow/utils/PairGenerator.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/utils/PairGenerator.java
@@ -1,20 +1,19 @@
 /*
  * Copyright (C) 2014 Google Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
- *
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
  * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
 package com.google.cloud.genomics.dataflow.utils;
 
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.RandomAccess;
@@ -28,13 +27,25 @@ import com.google.common.collect.Iterators;
 import com.google.common.collect.Range;
 
 /**
- * Generates all pairs of the elements in the iterable with or without replacement.
+ * Generates all combinations (not permutations) of pairs of the elements in the iterable.
  *
  */
 public class PairGenerator {
 
+  /**
+   * Generates all combinations (not permutations) of pairs of the elements in the iterable.
+   * 
+   * The pairs are often used as keys for results in many n^2 analyses where we end up with
+   * (n*(n-1))/2 or ((n*(n-1))/2)+n results.
+   * 
+   * @param list
+   * @param withReplacement - When true an additional N pairs will be generated (one for each
+   *        element in the list) in addition to the Nchoose2 pairs.
+   * @param comparator - used to enforce an order upon the elements within each pair
+   * @return
+   */
   public static <X, L extends List<? extends X> & RandomAccess> FluentIterable<KV<X, X>> allPairs(
-      final L list, final boolean withReplacement) {
+      final L list, final boolean withReplacement, final Comparator<X> comparator) {
     return FluentIterable.from(
         ContiguousSet.create(Range.closedOpen(0, list.size()), DiscreteDomain.integers()))
         .transformAndConcat(new Function<Integer, Iterable<KV<X, X>>>() {
@@ -44,18 +55,22 @@ public class PairGenerator {
               @Override
               public Iterator<KV<X, X>> iterator() {
                 Integer iteratorIndex = i;
-                if(!withReplacement) {
+                if (!withReplacement) {
                   iteratorIndex++;
                 }
-                return Iterators.transform(list.listIterator(iteratorIndex), new Function<X, KV<X, X>>() {
+                return Iterators.transform(list.listIterator(iteratorIndex),
+                    new Function<X, KV<X, X>>() {
 
-                  private final X key = list.get(i);
+                      private final X key = list.get(i);
 
-                  @Override
-                  public KV<X, X> apply(X value) {
-                    return KV.of(key, value);
-                  }
-                });
+                      @Override
+                      public KV<X, X> apply(X value) {
+                        if (0 < comparator.compare(key, value)) {
+                          return KV.of(value, key);
+                        }
+                        return KV.of(key, value);
+                      }
+                    });
               }
             };
           }

--- a/src/main/java/com/google/cloud/genomics/dataflow/utils/PairGenerator.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/utils/PairGenerator.java
@@ -28,24 +28,32 @@ import com.google.common.collect.Range;
 
 /**
  * Generates all combinations (not permutations) of pairs of the elements in the iterable.
- *
+ * 
+ * WITHOUT_REPLACEMENT - generate Nchoose2 combinations WITH_REPLACEMENT- generate Nchoose2
+ * combinations plus an additional N pairs (one for each element in the list)
  */
-public class PairGenerator {
+public enum PairGenerator {
+
+  WITH_REPLACEMENT(true), WITHOUT_REPLACEMENT(false);
+
+  private final boolean withReplacement;
+
+  private PairGenerator(boolean withReplacement) {
+    this.withReplacement = withReplacement;
+  }
 
   /**
-   * Generates all combinations (not permutations) of pairs of the elements in the iterable.
+   * * Generates all combinations (not permutations) of pairs of the elements in the iterable.
    * 
    * The pairs are often used as keys for results in many n^2 analyses where we end up with
    * (n*(n-1))/2 or ((n*(n-1))/2)+n results.
    * 
    * @param list
-   * @param withReplacement - When true an additional N pairs will be generated (one for each
-   *        element in the list) in addition to the Nchoose2 pairs.
    * @param comparator - used to enforce an order upon the elements within each pair
-   * @return
+   * @return the pairs
    */
-  public static <X, L extends List<? extends X> & RandomAccess> FluentIterable<KV<X, X>> allPairs(
-      final L list, final boolean withReplacement, final Comparator<X> comparator) {
+  public <X, L extends List<? extends X> & RandomAccess> FluentIterable<KV<X, X>> allPairs(
+      final L list, final Comparator<? super X> comparator) {
     return FluentIterable.from(
         ContiguousSet.create(Range.closedOpen(0, list.size()), DiscreteDomain.integers()))
         .transformAndConcat(new Function<Integer, Iterable<KV<X, X>>>() {
@@ -54,7 +62,7 @@ public class PairGenerator {
             return new Iterable<KV<X, X>>() {
               @Override
               public Iterator<KV<X, X>> iterator() {
-                Integer iteratorIndex = i;
+                int iteratorIndex = i;
                 if (!withReplacement) {
                   iteratorIndex++;
                 }
@@ -65,10 +73,8 @@ public class PairGenerator {
 
                       @Override
                       public KV<X, X> apply(X value) {
-                        if (0 < comparator.compare(key, value)) {
-                          return KV.of(value, key);
-                        }
-                        return KV.of(key, value);
+                        boolean swap = 0 < comparator.compare(key, value);
+                        return KV.of(swap ? value : key, swap ? key : value);
                       }
                     });
               }
@@ -76,5 +82,4 @@ public class PairGenerator {
           }
         });
   }
-
 }

--- a/src/main/java/com/google/cloud/genomics/dataflow/utils/PairGenerator.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/utils/PairGenerator.java
@@ -27,10 +27,14 @@ import com.google.common.collect.FluentIterable;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Range;
 
+/**
+ * Generates all pairs of the elements in the iterable with or without replacement.
+ *
+ */
 public class PairGenerator {
 
   public static <X, L extends List<? extends X> & RandomAccess> FluentIterable<KV<X, X>> allPairs(
-      final L list) {
+      final L list, final boolean withReplacement) {
     return FluentIterable.from(
         ContiguousSet.create(Range.closedOpen(0, list.size()), DiscreteDomain.integers()))
         .transformAndConcat(new Function<Integer, Iterable<KV<X, X>>>() {
@@ -39,7 +43,11 @@ public class PairGenerator {
             return new Iterable<KV<X, X>>() {
               @Override
               public Iterator<KV<X, X>> iterator() {
-                return Iterators.transform(list.listIterator(i), new Function<X, KV<X, X>>() {
+                Integer iteratorIndex = i;
+                if(!withReplacement) {
+                  iteratorIndex++;
+                }
+                return Iterators.transform(list.listIterator(iteratorIndex), new Function<X, KV<X, X>>() {
 
                   private final X key = list.get(i);
 

--- a/src/main/java/com/google/cloud/genomics/dataflow/utils/VariantUtils.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/utils/VariantUtils.java
@@ -22,6 +22,7 @@ import com.google.common.base.Function;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Ordering;
 
 public class VariantUtils {
 
@@ -46,12 +47,11 @@ public class VariantUtils {
   /**
    * Comparator for sorting calls by call set name.
    */
-  public static class CallComparator implements Comparator<Call> {
-    @Override
-    public int compare(Call c1, Call c2) {
-      return c1.getCallSetName().compareTo(c2.getCallSetName());
-    }
-  }
-
-
+  public static final Comparator<Call> CALL_COMPARATOR = Ordering.natural().onResultOf(
+      new Function<Call, String>() {
+        @Override
+        public String apply(Call call) {
+          return call.getCallSetName();
+        }
+      });
 }

--- a/src/main/java/com/google/cloud/genomics/dataflow/utils/VariantUtils.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/utils/VariantUtils.java
@@ -13,29 +13,31 @@
  */
 package com.google.cloud.genomics.dataflow.utils;
 
+import java.util.List;
+
 import com.google.api.services.genomics.model.Variant;
+import com.google.common.base.Function;
+import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
+import com.google.common.collect.Iterables;
 
 public class VariantUtils {
 
-  public static boolean isSnp(Variant variant) {
-    if (!isVariant(variant) || 1 != variant.getReferenceBases().length()) {
-      return false;
-    }
-    
-    for (String alt : variant.getAlternateBases()) {
-      if(1 != alt.length()) {
-        return false;
-      }
-    }
-    
-    return true;
-  }
-
   public static boolean isVariant(Variant variant) {
-    if (null == variant.getAlternateBases() || variant.getAlternateBases().isEmpty()) {
-      return false;
-    }
-    return true;
+    List<String> alternateBases = variant.getAlternateBases();
+    return !(null == alternateBases || alternateBases.isEmpty());
   }
 
+  public static boolean isSnp(Variant variant) {
+    return isVariant(variant) && LENGTH_IS_1.apply(variant.getReferenceBases())
+        && Iterables.all(variant.getAlternateBases(), LENGTH_IS_1);
+  }
+
+  private static final Predicate<String> LENGTH_IS_1 = Predicates.compose(Predicates.equalTo(1),
+      new Function<String, Integer>() {
+        @Override
+        public Integer apply(String string) {
+          return string.length();
+        }
+      });
 }

--- a/src/main/java/com/google/cloud/genomics/dataflow/utils/VariantUtils.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/utils/VariantUtils.java
@@ -13,8 +13,10 @@
  */
 package com.google.cloud.genomics.dataflow.utils;
 
+import java.util.Comparator;
 import java.util.List;
 
+import com.google.api.services.genomics.model.Call;
 import com.google.api.services.genomics.model.Variant;
 import com.google.common.base.Function;
 import com.google.common.base.Predicate;
@@ -40,4 +42,16 @@ public class VariantUtils {
           return string.length();
         }
       });
+
+  /**
+   * Comparator for sorting calls by call set name.
+   */
+  public static class CallComparator implements Comparator<Call> {
+    @Override
+    public int compare(Call c1, Call c2) {
+      return c1.getCallSetName().compareTo(c2.getCallSetName());
+    }
+  }
+
+
 }

--- a/src/main/java/com/google/cloud/genomics/dataflow/utils/VariantUtils.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/utils/VariantUtils.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2015 Google Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.genomics.dataflow.utils;
+
+import com.google.api.services.genomics.model.Variant;
+
+public class VariantUtils {
+
+  public static boolean isSnp(Variant variant) {
+    if (!isVariant(variant) || 1 != variant.getReferenceBases().length()) {
+      return false;
+    }
+    
+    for (String alt : variant.getAlternateBases()) {
+      if(1 != alt.length()) {
+        return false;
+      }
+    }
+    
+    return true;
+  }
+
+  public static boolean isVariant(Variant variant) {
+    if (null == variant.getAlternateBases() || variant.getAlternateBases().isEmpty()) {
+      return false;
+    }
+    return true;
+  }
+
+}

--- a/src/test/java/com/google/cloud/genomics/dataflow/functions/AlleleSimilarityCalculatorTest.java
+++ b/src/test/java/com/google/cloud/genomics/dataflow/functions/AlleleSimilarityCalculatorTest.java
@@ -1,16 +1,14 @@
 package com.google.cloud.genomics.dataflow.functions;
 
-import static com.google.common.collect.Lists.newArrayList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import org.hamcrest.CoreMatchers;
-import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 
 import com.google.api.services.genomics.model.Variant;
@@ -20,17 +18,14 @@ import com.google.cloud.genomics.dataflow.utils.DataUtils;
 
 public class AlleleSimilarityCalculatorTest {
 
-  static final Variant snp1 = DataUtils.makeVariant("chr7", 200019, 200020, "T", newArrayList("G"),
+  static final Variant snp1 = DataUtils.makeVariant("chr7", 200019, 200020, "T", Collections.singletonList("G"),
       DataUtils.makeCall("het-alt sample", 1, 0), DataUtils.makeCall("hom-alt sample", 1, 1),
       DataUtils.makeCall("hom-ref sample", 0, 0), DataUtils.makeCall("hom-nocall sample", -1, -1),
       DataUtils.makeCall("ref-nocall sample", -1, 0));
 
-  static final Variant snp2 = DataUtils.makeVariant("chr7", 200020, 200021, "C", newArrayList("A"),
+  static final Variant snp2 = DataUtils.makeVariant("chr7", 200020, 200021, "C", Collections.singletonList("A"),
       DataUtils.makeCall("hom-alt sample", 1, 1), DataUtils.makeCall("het-alt sample", 0, 1),
       DataUtils.makeCall("ref-nocall sample", 0, -1));
-
-  @Before
-  public void setUp() throws Exception {}
 
   @Test
   public void testIsReferenceMajor() {
@@ -53,7 +48,7 @@ public class AlleleSimilarityCalculatorTest {
 
     List<KV<KV<String, String>, KV<Double, Integer>>> outputSnp1 = simFn.processBatch(snp1);
     assertEquals(6, outputSnp1.size());
-    Assert.assertThat(outputSnp1, CoreMatchers.hasItems(
+    assertThat(outputSnp1, CoreMatchers.hasItems(
         KV.of(KV.of("het-alt sample", "ref-nocall sample"), KV.of(0.0, 1)),
         KV.of(KV.of("het-alt sample", "hom-ref sample"), KV.of(0.0, 1)),
         KV.of(KV.of("het-alt sample", "hom-alt sample"), KV.of(1.0, 1)),
@@ -63,7 +58,7 @@ public class AlleleSimilarityCalculatorTest {
 
     List<KV<KV<String, String>, KV<Double, Integer>>> outputSnp2 = simFn.processBatch(snp2);
     assertEquals(3, outputSnp2.size());
-    Assert.assertThat(
+    assertThat(
         outputSnp2,
         CoreMatchers.hasItems(KV.of(KV.of("het-alt sample", "hom-alt sample"), KV.of(0.0, 1)),
             KV.of(KV.of("het-alt sample", "ref-nocall sample"), KV.of(1.0, 1)),
@@ -72,7 +67,7 @@ public class AlleleSimilarityCalculatorTest {
     Variant[] input = new Variant[] {snp1, snp2};
     List<KV<KV<String, String>, KV<Double, Integer>>> outputBoth = simFn.processBatch(input);
     assertEquals(6, outputBoth.size());
-    Assert.assertThat(outputBoth, CoreMatchers.hasItems(
+    assertThat(outputBoth, CoreMatchers.hasItems(
         KV.of(KV.of("het-alt sample", "ref-nocall sample"), KV.of(1.0, 2)),
         KV.of(KV.of("het-alt sample", "hom-ref sample"), KV.of(0.0, 1)),
         KV.of(KV.of("het-alt sample", "hom-alt sample"), KV.of(1.0, 2)),

--- a/src/test/java/com/google/cloud/genomics/dataflow/functions/AlleleSimilarityCalculatorTest.java
+++ b/src/test/java/com/google/cloud/genomics/dataflow/functions/AlleleSimilarityCalculatorTest.java
@@ -1,0 +1,73 @@
+package com.google.cloud.genomics.dataflow.functions;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.api.services.genomics.model.Variant;
+import com.google.cloud.dataflow.sdk.transforms.DoFnTester;
+import com.google.cloud.dataflow.sdk.values.KV;
+import com.google.cloud.genomics.dataflow.utils.DataUtils;
+
+public class AlleleSimilarityCalculatorTest {
+
+  static final Variant snp1 = DataUtils.makeVariant("chr7", 200019, 200020, "T",
+      newArrayList(Arrays.asList("G")), DataUtils.makeCall("het-alt sample", 1, 0),
+      DataUtils.makeCall("hom-alt sample", 1, 1), DataUtils.makeCall("hom-ref sample", 0, 0),
+      DataUtils.makeCall("hom-nocall sample", -1, -1),
+      DataUtils.makeCall("ref-nocall sample", -1, 0));
+
+  static final Variant snp2 = DataUtils.makeVariant("chr7", 200020, 200021, "C",
+      newArrayList(Arrays.asList("A")), DataUtils.makeCall("hom-alt sample", 1, 1),
+      DataUtils.makeCall("het-alt sample", 0, 1), DataUtils.makeCall("ref-nocall sample", 0, -1));
+
+  @Before
+  public void setUp() throws Exception {}
+
+  @Test
+  public void testIsReferenceMajor() {
+    assertTrue(AlleleSimilarityCalculator.isReferenceMajor(snp1));
+    assertFalse(AlleleSimilarityCalculator.isReferenceMajor(snp2));
+  }
+
+  @Test
+  public void testGetSamplesWithVariant() {
+    assertEquals(4, AlleleSimilarityCalculator.getSamplesWithVariant(snp1).size());
+    assertEquals(3, AlleleSimilarityCalculator.getSamplesWithVariant(snp2).size());
+  }
+
+  @Test
+  public void testSharedMinorAllSimilarityFn() {
+
+    CallSimilarityCalculatorFactory fac = new SharedMinorAllelesCalculatorFactory();
+    DoFnTester<Variant, KV<KV<String, String>, KV<Double, Integer>>> simFn =
+        DoFnTester.of(new AlleleSimilarityCalculator(fac));
+
+    List<KV<KV<String, String>, KV<Double, Integer>>> output = simFn.processBatch(snp1);
+    assertEquals(6, output.size());
+    Assert.assertThat(output, CoreMatchers.hasItems(
+        KV.of(KV.of("het-alt sample", "ref-nocall sample"), KV.of(0.0, 1)),
+        KV.of(KV.of("het-alt sample", "hom-ref sample"), KV.of(0.0, 1)),
+        KV.of(KV.of("het-alt sample", "hom-alt sample"), KV.of(1.0, 1)),
+        KV.of(KV.of("hom-ref sample", "ref-nocall sample"), KV.of(0.0, 1)),
+        KV.of(KV.of("hom-alt sample", "ref-nocall sample"), KV.of(0.0, 1)),
+        KV.of(KV.of("hom-alt sample", "hom-ref sample"), KV.of(0.0, 1))));
+
+    output = simFn.processBatch(snp2);
+    assertEquals(3, output.size());
+    Assert.assertThat(
+        output,
+        CoreMatchers.hasItems(KV.of(KV.of("hom-alt sample", "het-alt sample"), KV.of(0.0, 1)),
+            KV.of(KV.of("het-alt sample", "ref-nocall sample"), KV.of(1.0, 1)),
+            KV.of(KV.of("hom-alt sample", "ref-nocall sample"), KV.of(0.0, 1))));
+  }
+}

--- a/src/test/java/com/google/cloud/genomics/dataflow/functions/AlleleSimilarityCalculatorTest.java
+++ b/src/test/java/com/google/cloud/genomics/dataflow/functions/AlleleSimilarityCalculatorTest.java
@@ -20,15 +20,14 @@ import com.google.cloud.genomics.dataflow.utils.DataUtils;
 
 public class AlleleSimilarityCalculatorTest {
 
-  static final Variant snp1 = DataUtils.makeVariant("chr7", 200019, 200020, "T",
-      newArrayList(Arrays.asList("G")), DataUtils.makeCall("het-alt sample", 1, 0),
-      DataUtils.makeCall("hom-alt sample", 1, 1), DataUtils.makeCall("hom-ref sample", 0, 0),
-      DataUtils.makeCall("hom-nocall sample", -1, -1),
+  static final Variant snp1 = DataUtils.makeVariant("chr7", 200019, 200020, "T", newArrayList("G"),
+      DataUtils.makeCall("het-alt sample", 1, 0), DataUtils.makeCall("hom-alt sample", 1, 1),
+      DataUtils.makeCall("hom-ref sample", 0, 0), DataUtils.makeCall("hom-nocall sample", -1, -1),
       DataUtils.makeCall("ref-nocall sample", -1, 0));
 
-  static final Variant snp2 = DataUtils.makeVariant("chr7", 200020, 200021, "C",
-      newArrayList(Arrays.asList("A")), DataUtils.makeCall("hom-alt sample", 1, 1),
-      DataUtils.makeCall("het-alt sample", 0, 1), DataUtils.makeCall("ref-nocall sample", 0, -1));
+  static final Variant snp2 = DataUtils.makeVariant("chr7", 200020, 200021, "C", newArrayList("A"),
+      DataUtils.makeCall("hom-alt sample", 1, 1), DataUtils.makeCall("het-alt sample", 0, 1),
+      DataUtils.makeCall("ref-nocall sample", 0, -1));
 
   @Before
   public void setUp() throws Exception {}
@@ -52,9 +51,9 @@ public class AlleleSimilarityCalculatorTest {
     DoFnTester<Variant, KV<KV<String, String>, KV<Double, Integer>>> simFn =
         DoFnTester.of(new AlleleSimilarityCalculator(fac));
 
-    List<KV<KV<String, String>, KV<Double, Integer>>> output = simFn.processBatch(snp1);
-    assertEquals(6, output.size());
-    Assert.assertThat(output, CoreMatchers.hasItems(
+    List<KV<KV<String, String>, KV<Double, Integer>>> outputSnp1 = simFn.processBatch(snp1);
+    assertEquals(6, outputSnp1.size());
+    Assert.assertThat(outputSnp1, CoreMatchers.hasItems(
         KV.of(KV.of("het-alt sample", "ref-nocall sample"), KV.of(0.0, 1)),
         KV.of(KV.of("het-alt sample", "hom-ref sample"), KV.of(0.0, 1)),
         KV.of(KV.of("het-alt sample", "hom-alt sample"), KV.of(1.0, 1)),
@@ -62,12 +61,24 @@ public class AlleleSimilarityCalculatorTest {
         KV.of(KV.of("hom-alt sample", "ref-nocall sample"), KV.of(0.0, 1)),
         KV.of(KV.of("hom-alt sample", "hom-ref sample"), KV.of(0.0, 1))));
 
-    output = simFn.processBatch(snp2);
-    assertEquals(3, output.size());
+    List<KV<KV<String, String>, KV<Double, Integer>>> outputSnp2 = simFn.processBatch(snp2);
+    assertEquals(3, outputSnp2.size());
     Assert.assertThat(
-        output,
-        CoreMatchers.hasItems(KV.of(KV.of("hom-alt sample", "het-alt sample"), KV.of(0.0, 1)),
+        outputSnp2,
+        CoreMatchers.hasItems(KV.of(KV.of("het-alt sample", "hom-alt sample"), KV.of(0.0, 1)),
             KV.of(KV.of("het-alt sample", "ref-nocall sample"), KV.of(1.0, 1)),
             KV.of(KV.of("hom-alt sample", "ref-nocall sample"), KV.of(0.0, 1))));
+
+    Variant[] input = new Variant[] {snp1, snp2};
+    List<KV<KV<String, String>, KV<Double, Integer>>> outputBoth = simFn.processBatch(input);
+    assertEquals(6, outputBoth.size());
+    Assert.assertThat(outputBoth, CoreMatchers.hasItems(
+        KV.of(KV.of("het-alt sample", "ref-nocall sample"), KV.of(1.0, 2)),
+        KV.of(KV.of("het-alt sample", "hom-ref sample"), KV.of(0.0, 1)),
+        KV.of(KV.of("het-alt sample", "hom-alt sample"), KV.of(1.0, 2)),
+        KV.of(KV.of("hom-ref sample", "ref-nocall sample"), KV.of(0.0, 1)),
+        KV.of(KV.of("hom-alt sample", "ref-nocall sample"), KV.of(0.0, 2)),
+        KV.of(KV.of("hom-alt sample", "hom-ref sample"), KV.of(0.0, 1))));
+
   }
 }

--- a/src/test/java/com/google/cloud/genomics/dataflow/functions/CallSimilarityCalculatorTest.java
+++ b/src/test/java/com/google/cloud/genomics/dataflow/functions/CallSimilarityCalculatorTest.java
@@ -62,10 +62,10 @@ public class CallSimilarityCalculatorTest {
     calls.add(DataUtils.makeCall(H2, 1, 0, 1));
     calls.add(DataUtils.makeCall(H3, 1, 0, 0));
 
-    variants.add(DataUtils.makeVariant(calls.get(0), calls.get(1), calls.get(2)));
-    variants.add(DataUtils.makeVariant(calls.get(0), calls.get(3), calls.get(4)));
-    variants.add(DataUtils.makeVariant(calls.get(0), calls.get(5), calls.get(6)));
-    variants.add(DataUtils.makeVariant(calls.get(0), calls.get(7), calls.get(8)));
+    variants.add(DataUtils.makeSimpleVariant(calls.get(0), calls.get(1), calls.get(2)));
+    variants.add(DataUtils.makeSimpleVariant(calls.get(0), calls.get(3), calls.get(4)));
+    variants.add(DataUtils.makeSimpleVariant(calls.get(0), calls.get(5), calls.get(6)));
+    variants.add(DataUtils.makeSimpleVariant(calls.get(0), calls.get(7), calls.get(8)));
   }
 
   @Test

--- a/src/test/java/com/google/cloud/genomics/dataflow/functions/CallSimilarityCalculatorTest.java
+++ b/src/test/java/com/google/cloud/genomics/dataflow/functions/CallSimilarityCalculatorTest.java
@@ -123,16 +123,10 @@ public class CallSimilarityCalculatorTest {
     Map<KV<String, String>, KV<Double, Integer>> fnOutputMap =
         calculatorOutputAsMap(new SharedAllelesRatioCalculatorFactory());
 
-    assertEquals(fnOutputMap.get(KV.of(H1, H1)).getKey(), 4.0, DELTA);
-    assertEquals(fnOutputMap.get(KV.of(H2, H2)).getKey(), 4.0, DELTA);
-    assertEquals(fnOutputMap.get(KV.of(H3, H3)).getKey(), 4.0, DELTA);
     assertEquals(fnOutputMap.get(KV.of(H1, H2)).getKey(), 0.5 + 1.0 / 3.0, DELTA);
     assertEquals(fnOutputMap.get(KV.of(H1, H3)).getKey(), 1.0 + 1.0 / 3.0, DELTA);
     assertEquals(fnOutputMap.get(KV.of(H2, H3)).getKey(), 1.0 + 2.0 / 3.0, DELTA);
 
-    assertEquals(4, fnOutputMap.get(KV.of(H1, H1)).getValue().intValue());
-    assertEquals(4, fnOutputMap.get(KV.of(H2, H2)).getValue().intValue());
-    assertEquals(4, fnOutputMap.get(KV.of(H3, H3)).getValue().intValue());
     assertEquals(4, fnOutputMap.get(KV.of(H1, H2)).getValue().intValue());
     assertEquals(4, fnOutputMap.get(KV.of(H1, H3)).getValue().intValue());
     assertEquals(4, fnOutputMap.get(KV.of(H2, H3)).getValue().intValue());
@@ -143,16 +137,10 @@ public class CallSimilarityCalculatorTest {
     Map<KV<String, String>, KV<Double, Integer>> fnOutputMap =
         calculatorOutputAsMap(new SharedMinorAllelesCalculatorFactory());
 
-    assertEquals(4.0, fnOutputMap.get(KV.of(H1, H1)).getKey(), DELTA);
-    assertEquals(4.0, fnOutputMap.get(KV.of(H2, H2)).getKey(), DELTA);
-    assertEquals(4.0, fnOutputMap.get(KV.of(H3, H3)).getKey(), DELTA);
     assertEquals(0.0, fnOutputMap.get(KV.of(H1, H2)).getKey(), DELTA);
     assertEquals(0.0, fnOutputMap.get(KV.of(H1, H3)).getKey(), DELTA);
     assertEquals(2.0, fnOutputMap.get(KV.of(H2, H3)).getKey(), DELTA);
 
-    assertEquals(4, fnOutputMap.get(KV.of(H1, H1)).getValue().intValue());
-    assertEquals(4, fnOutputMap.get(KV.of(H2, H2)).getValue().intValue());
-    assertEquals(4, fnOutputMap.get(KV.of(H3, H3)).getValue().intValue());
     assertEquals(4, fnOutputMap.get(KV.of(H1, H2)).getValue().intValue());
     assertEquals(4, fnOutputMap.get(KV.of(H1, H3)).getValue().intValue());
     assertEquals(4, fnOutputMap.get(KV.of(H2, H3)).getValue().intValue());

--- a/src/test/java/com/google/cloud/genomics/dataflow/functions/ExtractSimilarCallsetsTest.java
+++ b/src/test/java/com/google/cloud/genomics/dataflow/functions/ExtractSimilarCallsetsTest.java
@@ -37,19 +37,7 @@ import java.util.List;
 @RunWith(JUnit4.class)
 public class ExtractSimilarCallsetsTest {
 
-  @Test
-  public void testAllPairs() {
-    assertEquals(
-        Collections.emptyList(),
-        PairGenerator.allPairs(Lists.newArrayList(Collections.emptyList())).toList());
-    assertEquals(
-        Collections.singletonList(KV.of(1, 1)),
-        PairGenerator.allPairs(Lists.newArrayList(Collections.singletonList(1))).toList());
-    assertEquals(
-        Arrays.asList(KV.of(1, 1), KV.of(1, 2), KV.of(1, 3), KV.of(2, 2), KV.of(2, 3), KV.of(3, 3)),
-        PairGenerator.allPairs(Lists.newArrayList(Arrays.asList(1, 2, 3))).toList());
-  }
-
+ 
   @Test
   public void testGetSamplesWithVariant() throws Exception {
     Variant variant = new Variant();

--- a/src/test/java/com/google/cloud/genomics/dataflow/functions/JoinGvcfVariantsTest.java
+++ b/src/test/java/com/google/cloud/genomics/dataflow/functions/JoinGvcfVariantsTest.java
@@ -97,6 +97,7 @@ public class JoinGvcfVariantsTest {
   public void testVariantComparator() {
     assertEquals(-1, new VariantComparator().compare(blockRecord1, snp1));
     assertEquals(1, new VariantComparator().compare(blockRecord2, snp1));
+    assertEquals(-1, new VariantComparator().compare(snp1, snp2));
 
     // Two variants at the same location
     assertEquals(0, new VariantComparator().compare(

--- a/src/test/java/com/google/cloud/genomics/dataflow/functions/JoinGvcfVariantsTest.java
+++ b/src/test/java/com/google/cloud/genomics/dataflow/functions/JoinGvcfVariantsTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright (C) 2015 Google Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.genomics.dataflow.functions;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.collection.IsIterableWithSize;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import com.google.api.services.genomics.model.Call;
+import com.google.api.services.genomics.model.Variant;
+import com.google.cloud.dataflow.sdk.Pipeline;
+import com.google.cloud.dataflow.sdk.testing.DataflowAssert;
+import com.google.cloud.dataflow.sdk.testing.TestPipeline;
+import com.google.cloud.dataflow.sdk.transforms.Create;
+import com.google.cloud.dataflow.sdk.transforms.DoFnTester;
+import com.google.cloud.dataflow.sdk.transforms.GroupByKey;
+import com.google.cloud.dataflow.sdk.transforms.ParDo;
+import com.google.cloud.dataflow.sdk.transforms.SerializableFunction;
+import com.google.cloud.dataflow.sdk.values.KV;
+import com.google.cloud.dataflow.sdk.values.PCollection;
+import com.google.cloud.genomics.dataflow.functions.JoinGvcfVariants.VariantComparator;
+import com.google.cloud.genomics.dataflow.utils.DataUtils;
+import com.google.cloud.genomics.dataflow.utils.DataflowWorkarounds;
+
+@RunWith(JUnit4.class)
+public class JoinGvcfVariantsTest {
+
+  static final Call[] variantCalls = new Call[] {DataUtils.makeCall("het-alt sample", 1, 0),
+      DataUtils.makeCall("hom-alt sample", 1, 1)};
+
+  static final Call[] blockRecord1Calls = new Call[] {DataUtils.makeCall("hom sample", 0, 0),
+      DataUtils.makeCall("no call sample", -1, -1)};
+
+  static final Call[] blockRecord2Calls = new Call[] {DataUtils.makeCall("hom no-call sample", -1,
+      0)};
+
+  static final Variant expectedSnp1 = DataUtils.makeVariant("chr7", 200010, 200011, "A",
+      newArrayList(Arrays.asList("C")), variantCalls[0], variantCalls[1], blockRecord1Calls[0],
+      blockRecord1Calls[1]);
+
+  static final Variant expectedSnp2 = DataUtils.makeVariant("chr7", 200019, 200020, "T",
+      newArrayList(Arrays.asList("G")), variantCalls[0], variantCalls[1], blockRecord1Calls[0],
+      blockRecord1Calls[1], blockRecord2Calls[0]);
+
+  static final Variant expectedInsert = DataUtils.makeVariant("chr7", 200010, 200011, "A",
+      newArrayList(Arrays.asList("AC")), variantCalls);
+
+  Variant snp1;
+  Variant snp2;
+  Variant insert;
+  Variant blockRecord1;
+  Variant blockRecord2;
+  Variant[] input;
+
+  @Before
+  public void setUp() {
+    snp1 =
+        DataUtils.makeVariant("chr7", 200010, 200011, "A", newArrayList(Arrays.asList("C")),
+            variantCalls);
+
+    snp2 =
+        DataUtils.makeVariant("chr7", 200019, 200020, "T", newArrayList(Arrays.asList("G")),
+            variantCalls);
+
+    insert =
+        DataUtils.makeVariant("chr7", 200010, 200011, "A", newArrayList(Arrays.asList("AC")),
+            variantCalls);
+
+    blockRecord1 = DataUtils.makeVariant("chr7", 199005, 202050, "A", null, blockRecord1Calls);
+
+    blockRecord2 = DataUtils.makeVariant("chr7", 200011, 200020, "A", null, blockRecord2Calls);
+
+    input = new Variant[] {snp1, snp2, insert, blockRecord1, blockRecord2};
+  }
+
+  @Test
+  public void testVariantComparator() {
+    assertEquals(-1, new VariantComparator().compare(blockRecord1, snp1));
+    assertEquals(1, new VariantComparator().compare(blockRecord2, snp1));
+
+    // Two variants at the same location
+    assertEquals(0, new VariantComparator().compare(DataUtils.makeVariant("chr7", 200010, 200011,
+        "A", newArrayList(Arrays.asList("C")), (Call[]) null), DataUtils.makeVariant("chr7",
+        200010, 200011, "A", newArrayList(Arrays.asList("T")), (Call[]) null)));
+
+    // Block record and variant at the same location
+    assertEquals(1, new VariantComparator().compare(DataUtils.makeVariant("chr7", 200010, 200011,
+        "A", newArrayList(Arrays.asList("C")), (Call[]) null), DataUtils.makeVariant("chr7",
+        200010, 200011, "A", null, (Call[]) null)));
+  }
+
+  @Test
+  public void testIsOverlapping() {
+    assertTrue(JoinGvcfVariants.isOverlapping(blockRecord1, snp1));
+    assertTrue(JoinGvcfVariants.isOverlapping(blockRecord1, snp2));
+    assertFalse(JoinGvcfVariants.isOverlapping(blockRecord2, snp1));
+    assertTrue(JoinGvcfVariants.isOverlapping(blockRecord2, snp2));
+  }
+
+  @Test
+  public void testBinVariantsFn() {
+
+    DoFnTester<Variant, KV<KV<String, Integer>, Variant>> binVariantsFn =
+        DoFnTester.of(new JoinGvcfVariants.BinVariants());
+
+    List<KV<KV<String, Integer>, Variant>> binVariantsOutput = binVariantsFn.processBatch(input);
+    Assert.assertThat(binVariantsOutput, CoreMatchers.hasItem(KV.of(KV.of("chr7", 200), snp1)));
+    Assert.assertThat(binVariantsOutput, CoreMatchers.hasItem(KV.of(KV.of("chr7", 200), snp2)));
+    Assert.assertThat(binVariantsOutput, CoreMatchers.hasItem(KV.of(KV.of("chr7", 200), insert)));
+    Assert.assertThat(binVariantsOutput,
+        CoreMatchers.hasItem(KV.of(KV.of("chr7", 199), blockRecord1)));
+    Assert.assertThat(binVariantsOutput,
+        CoreMatchers.hasItem(KV.of(KV.of("chr7", 200), blockRecord1)));
+    Assert.assertThat(binVariantsOutput,
+        CoreMatchers.hasItem(KV.of(KV.of("chr7", 201), blockRecord1)));
+    Assert.assertThat(binVariantsOutput,
+        CoreMatchers.hasItem(KV.of(KV.of("chr7", 202), blockRecord1)));
+    Assert.assertThat(binVariantsOutput,
+        CoreMatchers.hasItem(KV.of(KV.of("chr7", 200), blockRecord2)));
+    assertEquals(8, binVariantsOutput.size());
+  }
+
+  @Test
+  public void testJoinGvcfPipeline() {
+
+    Pipeline p = TestPipeline.create();
+    DataflowWorkarounds.registerGenomicsCoders(p);
+
+    PCollection<Variant> inputVariants = p.apply(Create.of(input));
+
+    PCollection<KV<KV<String, Integer>, Variant>> binnedVariants =
+        inputVariants.apply(ParDo.of(new JoinGvcfVariants.BinVariants()));
+
+    // TODO check that windowing function is not splitting these groups across different windows
+    PCollection<KV<KV<String, Integer>, Iterable<Variant>>> groupedBinnedVariants =
+        binnedVariants.apply(GroupByKey.<KV<String, Integer>, Variant>create());
+
+    PCollection<Variant> mergedVariants =
+        groupedBinnedVariants.apply(ParDo.of(new JoinGvcfVariants.MergeVariants()));
+
+    DataflowAssert.that(mergedVariants).satisfies(
+        new AssertThatHasExpectedContentsForTestJoinGvcf());
+
+    p.run();
+  }
+
+  @SuppressWarnings("serial")
+  static class AssertThatHasExpectedContentsForTestJoinGvcf implements
+      SerializableFunction<Iterable<Variant>, Void> {
+
+    @Override
+    public Void apply(Iterable<Variant> actual) {
+      Assert.assertThat(actual, CoreMatchers.hasItem(expectedSnp1));
+      Assert.assertThat(actual, CoreMatchers.hasItem(expectedSnp2));
+      Assert.assertThat(actual, CoreMatchers.hasItem(expectedInsert));
+      Assert.assertThat(actual, IsIterableWithSize.<Variant>iterableWithSize(3));
+
+      return null;
+    }
+  }
+}

--- a/src/test/java/com/google/cloud/genomics/dataflow/functions/JoinGvcfVariantsTest.java
+++ b/src/test/java/com/google/cloud/genomics/dataflow/functions/JoinGvcfVariantsTest.java
@@ -18,7 +18,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import java.util.Arrays;
 import java.util.List;
 
 import org.hamcrest.CoreMatchers;
@@ -48,46 +47,40 @@ import com.google.cloud.genomics.dataflow.utils.DataflowWorkarounds;
 @RunWith(JUnit4.class)
 public class JoinGvcfVariantsTest {
 
-  static final Call[] variantCalls = new Call[] {DataUtils.makeCall("het-alt sample", 1, 0),
-      DataUtils.makeCall("hom-alt sample", 1, 1)};
+  private static final Call[] variantCalls = new Call[] {
+      DataUtils.makeCall("het-alt sample", 1, 0), DataUtils.makeCall("hom-alt sample", 1, 1)};
 
-  static final Call[] blockRecord1Calls = new Call[] {DataUtils.makeCall("hom sample", 0, 0),
-      DataUtils.makeCall("no call sample", -1, -1)};
+  private static final Call[] blockRecord1Calls = new Call[] {
+      DataUtils.makeCall("hom sample", 0, 0), DataUtils.makeCall("no call sample", -1, -1)};
 
-  static final Call[] blockRecord2Calls = new Call[] {DataUtils.makeCall("hom no-call sample", -1,
-      0)};
+  private static final Call[] blockRecord2Calls = new Call[] {DataUtils.makeCall(
+      "hom no-call sample", -1, 0)};
 
-  static final Variant expectedSnp1 = DataUtils.makeVariant("chr7", 200010, 200011, "A",
-      newArrayList(Arrays.asList("C")), variantCalls[0], variantCalls[1], blockRecord1Calls[0],
+  private static final Variant expectedSnp1 = DataUtils.makeVariant("chr7", 200010, 200011, "A",
+      newArrayList("C"), variantCalls[0], variantCalls[1], blockRecord1Calls[0],
       blockRecord1Calls[1]);
 
-  static final Variant expectedSnp2 = DataUtils.makeVariant("chr7", 200019, 200020, "T",
-      newArrayList(Arrays.asList("G")), variantCalls[0], variantCalls[1], blockRecord1Calls[0],
+  private static final Variant expectedSnp2 = DataUtils.makeVariant("chr7", 200019, 200020, "T",
+      newArrayList("G"), variantCalls[0], variantCalls[1], blockRecord1Calls[0],
       blockRecord1Calls[1], blockRecord2Calls[0]);
 
-  static final Variant expectedInsert = DataUtils.makeVariant("chr7", 200010, 200011, "A",
-      newArrayList(Arrays.asList("AC")), variantCalls);
+  private static final Variant expectedInsert = DataUtils.makeVariant("chr7", 200010, 200011, "A",
+      newArrayList("AC"), variantCalls);
 
-  Variant snp1;
-  Variant snp2;
-  Variant insert;
-  Variant blockRecord1;
-  Variant blockRecord2;
-  Variant[] input;
+  private Variant snp1;
+  private Variant snp2;
+  private Variant insert;
+  private Variant blockRecord1;
+  private Variant blockRecord2;
+  private Variant[] input;
 
   @Before
   public void setUp() {
-    snp1 =
-        DataUtils.makeVariant("chr7", 200010, 200011, "A", newArrayList(Arrays.asList("C")),
-            variantCalls);
+    snp1 = DataUtils.makeVariant("chr7", 200010, 200011, "A", newArrayList("C"), variantCalls);
 
-    snp2 =
-        DataUtils.makeVariant("chr7", 200019, 200020, "T", newArrayList(Arrays.asList("G")),
-            variantCalls);
+    snp2 = DataUtils.makeVariant("chr7", 200019, 200020, "T", newArrayList("G"), variantCalls);
 
-    insert =
-        DataUtils.makeVariant("chr7", 200010, 200011, "A", newArrayList(Arrays.asList("AC")),
-            variantCalls);
+    insert = DataUtils.makeVariant("chr7", 200010, 200011, "A", newArrayList("AC"), variantCalls);
 
     blockRecord1 = DataUtils.makeVariant("chr7", 199005, 202050, "A", null, blockRecord1Calls);
 
@@ -102,14 +95,14 @@ public class JoinGvcfVariantsTest {
     assertEquals(1, new VariantComparator().compare(blockRecord2, snp1));
 
     // Two variants at the same location
-    assertEquals(0, new VariantComparator().compare(DataUtils.makeVariant("chr7", 200010, 200011,
-        "A", newArrayList(Arrays.asList("C")), (Call[]) null), DataUtils.makeVariant("chr7",
-        200010, 200011, "A", newArrayList(Arrays.asList("T")), (Call[]) null)));
+    assertEquals(0, new VariantComparator().compare(
+        DataUtils.makeVariant("chr7", 200010, 200011, "A", newArrayList("C"), (Call[]) null),
+        DataUtils.makeVariant("chr7", 200010, 200011, "A", newArrayList("T"), (Call[]) null)));
 
     // Block record and variant at the same location
-    assertEquals(1, new VariantComparator().compare(DataUtils.makeVariant("chr7", 200010, 200011,
-        "A", newArrayList(Arrays.asList("C")), (Call[]) null), DataUtils.makeVariant("chr7",
-        200010, 200011, "A", null, (Call[]) null)));
+    assertEquals(1, new VariantComparator().compare(
+        DataUtils.makeVariant("chr7", 200010, 200011, "A", newArrayList("C"), (Call[]) null),
+        DataUtils.makeVariant("chr7", 200010, 200011, "A", null, (Call[]) null)));
   }
 
   @Test
@@ -123,23 +116,23 @@ public class JoinGvcfVariantsTest {
   @Test
   public void testBinVariantsFn() {
 
-    DoFnTester<Variant, KV<KV<String, Integer>, Variant>> binVariantsFn =
+    DoFnTester<Variant, KV<KV<String, Long>, Variant>> binVariantsFn =
         DoFnTester.of(new JoinGvcfVariants.BinVariants());
 
-    List<KV<KV<String, Integer>, Variant>> binVariantsOutput = binVariantsFn.processBatch(input);
-    Assert.assertThat(binVariantsOutput, CoreMatchers.hasItem(KV.of(KV.of("chr7", 200), snp1)));
-    Assert.assertThat(binVariantsOutput, CoreMatchers.hasItem(KV.of(KV.of("chr7", 200), snp2)));
-    Assert.assertThat(binVariantsOutput, CoreMatchers.hasItem(KV.of(KV.of("chr7", 200), insert)));
+    List<KV<KV<String, Long>, Variant>> binVariantsOutput = binVariantsFn.processBatch(input);
+    Assert.assertThat(binVariantsOutput, CoreMatchers.hasItem(KV.of(KV.of("chr7", 200L), snp1)));
+    Assert.assertThat(binVariantsOutput, CoreMatchers.hasItem(KV.of(KV.of("chr7", 200L), snp2)));
+    Assert.assertThat(binVariantsOutput, CoreMatchers.hasItem(KV.of(KV.of("chr7", 200L), insert)));
     Assert.assertThat(binVariantsOutput,
-        CoreMatchers.hasItem(KV.of(KV.of("chr7", 199), blockRecord1)));
+        CoreMatchers.hasItem(KV.of(KV.of("chr7", 199L), blockRecord1)));
     Assert.assertThat(binVariantsOutput,
-        CoreMatchers.hasItem(KV.of(KV.of("chr7", 200), blockRecord1)));
+        CoreMatchers.hasItem(KV.of(KV.of("chr7", 200L), blockRecord1)));
     Assert.assertThat(binVariantsOutput,
-        CoreMatchers.hasItem(KV.of(KV.of("chr7", 201), blockRecord1)));
+        CoreMatchers.hasItem(KV.of(KV.of("chr7", 201L), blockRecord1)));
     Assert.assertThat(binVariantsOutput,
-        CoreMatchers.hasItem(KV.of(KV.of("chr7", 202), blockRecord1)));
+        CoreMatchers.hasItem(KV.of(KV.of("chr7", 202L), blockRecord1)));
     Assert.assertThat(binVariantsOutput,
-        CoreMatchers.hasItem(KV.of(KV.of("chr7", 200), blockRecord2)));
+        CoreMatchers.hasItem(KV.of(KV.of("chr7", 200L), blockRecord2)));
     assertEquals(8, binVariantsOutput.size());
   }
 
@@ -151,12 +144,12 @@ public class JoinGvcfVariantsTest {
 
     PCollection<Variant> inputVariants = p.apply(Create.of(input));
 
-    PCollection<KV<KV<String, Integer>, Variant>> binnedVariants =
+    PCollection<KV<KV<String, Long>, Variant>> binnedVariants =
         inputVariants.apply(ParDo.of(new JoinGvcfVariants.BinVariants()));
 
     // TODO check that windowing function is not splitting these groups across different windows
-    PCollection<KV<KV<String, Integer>, Iterable<Variant>>> groupedBinnedVariants =
-        binnedVariants.apply(GroupByKey.<KV<String, Integer>, Variant>create());
+    PCollection<KV<KV<String, Long>, Iterable<Variant>>> groupedBinnedVariants =
+        binnedVariants.apply(GroupByKey.<KV<String, Long>, Variant>create());
 
     PCollection<Variant> mergedVariants =
         groupedBinnedVariants.apply(ParDo.of(new JoinGvcfVariants.MergeVariants()));

--- a/src/test/java/com/google/cloud/genomics/dataflow/utils/DataUtils.java
+++ b/src/test/java/com/google/cloud/genomics/dataflow/utils/DataUtils.java
@@ -33,12 +33,9 @@ public class DataUtils {
 
   public static Variant makeVariant(String referenceName, long start, long end,
       String referenceBases, List<String> alternateBases, Call... calls) {
-    Variant variant = new Variant();
-    variant.setReferenceName(referenceName);
-    variant.setStart(start);
-    variant.setEnd(end);
-    variant.setReferenceBases(referenceBases);
-    variant.setAlternateBases(alternateBases);
+    Variant variant =
+        new Variant().setReferenceName(referenceName).setStart(start).setEnd(end)
+            .setReferenceBases(referenceBases).setAlternateBases(alternateBases);
     if (null != calls) {
       variant.setCalls(newArrayList(calls));
     }

--- a/src/test/java/com/google/cloud/genomics/dataflow/utils/DataUtils.java
+++ b/src/test/java/com/google/cloud/genomics/dataflow/utils/DataUtils.java
@@ -1,16 +1,14 @@
 /*
  * Copyright (C) 2014 Google Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
- *
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
  * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
 package com.google.cloud.genomics.dataflow.utils;
@@ -18,6 +16,7 @@ package com.google.cloud.genomics.dataflow.utils;
 import static com.google.common.collect.Lists.newArrayList;
 
 import java.util.Arrays;
+import java.util.List;
 
 import com.google.api.services.genomics.model.Call;
 import com.google.api.services.genomics.model.Variant;
@@ -28,8 +27,22 @@ public class DataUtils {
     return new Call().setCallSetName(name).setGenotype(Arrays.asList(alleles));
   }
 
-  public static Variant makeVariant(Call... calls) {
+  public static Variant makeSimpleVariant(Call... calls) {
     return new Variant().setCalls(newArrayList(calls));
+  }
+
+  public static Variant makeVariant(String referenceName, long start, long end,
+      String referenceBases, List<String> alternateBases, Call... calls) {
+    Variant variant = new Variant();
+    variant.setReferenceName(referenceName);
+    variant.setStart(start);
+    variant.setEnd(end);
+    variant.setReferenceBases(referenceBases);
+    variant.setAlternateBases(alternateBases);
+    if (null != calls) {
+      variant.setCalls(newArrayList(calls));
+    }
+    return variant;
   }
 
 }

--- a/src/test/java/com/google/cloud/genomics/dataflow/utils/DataUtils.java
+++ b/src/test/java/com/google/cloud/genomics/dataflow/utils/DataUtils.java
@@ -13,8 +13,6 @@
  */
 package com.google.cloud.genomics.dataflow.utils;
 
-import static com.google.common.collect.Lists.newArrayList;
-
 import java.util.Arrays;
 import java.util.List;
 
@@ -28,7 +26,7 @@ public class DataUtils {
   }
 
   public static Variant makeSimpleVariant(Call... calls) {
-    return new Variant().setCalls(newArrayList(calls));
+    return new Variant().setCalls(Arrays.asList(calls));
   }
 
   public static Variant makeVariant(String referenceName, long start, long end,
@@ -37,7 +35,7 @@ public class DataUtils {
         new Variant().setReferenceName(referenceName).setStart(start).setEnd(end)
             .setReferenceBases(referenceBases).setAlternateBases(alternateBases);
     if (null != calls) {
-      variant.setCalls(newArrayList(calls));
+      variant.setCalls(Arrays.asList(calls));
     }
     return variant;
   }

--- a/src/test/java/com/google/cloud/genomics/dataflow/utils/PairGeneratorTest.java
+++ b/src/test/java/com/google/cloud/genomics/dataflow/utils/PairGeneratorTest.java
@@ -16,21 +16,21 @@ public class PairGeneratorTest {
   public void testAllPairsWithReplacement() {
     FluentIterable<KV<String, String>> pairs =
         PairGenerator.<String, ImmutableList<String>>allPairs(
-            ImmutableList.of("one", "two", "three"), true);
+            ImmutableList.of("one", "two", "three"), true, String.CASE_INSENSITIVE_ORDER);
     assertEquals(6, pairs.size());
     Assert.assertThat(
         pairs,
         CoreMatchers.hasItems(KV.of("one", "one"), KV.of("one", "two"), KV.of("one", "three"),
-            KV.of("two", "two"), KV.of("two", "three"), KV.of("three", "three")));
+            KV.of("two", "two"), KV.of("three", "two"), KV.of("three", "three")));
   }
 
   @Test
   public void testAllPairsWithoutReplacement() {
     FluentIterable<KV<String, String>> pairs =
         PairGenerator.<String, ImmutableList<String>>allPairs(
-            ImmutableList.of("one", "two", "three"), false);
+            ImmutableList.of("one", "two", "three"), false, String.CASE_INSENSITIVE_ORDER);
     assertEquals(3, pairs.size());
     Assert.assertThat(pairs,
-        CoreMatchers.hasItems(KV.of("one", "two"), KV.of("one", "three"), KV.of("two", "three")));
+        CoreMatchers.hasItems(KV.of("one", "two"), KV.of("one", "three"), KV.of("three", "two")));
   }
 }

--- a/src/test/java/com/google/cloud/genomics/dataflow/utils/PairGeneratorTest.java
+++ b/src/test/java/com/google/cloud/genomics/dataflow/utils/PairGeneratorTest.java
@@ -1,9 +1,9 @@
 package com.google.cloud.genomics.dataflow.utils;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
 
 import org.hamcrest.CoreMatchers;
-import org.junit.Assert;
 import org.junit.Test;
 
 import com.google.cloud.dataflow.sdk.values.KV;
@@ -15,10 +15,10 @@ public class PairGeneratorTest {
   @Test
   public void testAllPairsWithReplacement() {
     FluentIterable<KV<String, String>> pairs =
-        PairGenerator.<String, ImmutableList<String>>allPairs(
-            ImmutableList.of("one", "two", "three"), true, String.CASE_INSENSITIVE_ORDER);
+        PairGenerator.WITH_REPLACEMENT.allPairs(ImmutableList.of("one", "two", "three"),
+            String.CASE_INSENSITIVE_ORDER);
     assertEquals(6, pairs.size());
-    Assert.assertThat(
+    assertThat(
         pairs,
         CoreMatchers.hasItems(KV.of("one", "one"), KV.of("one", "two"), KV.of("one", "three"),
             KV.of("two", "two"), KV.of("three", "two"), KV.of("three", "three")));
@@ -27,10 +27,10 @@ public class PairGeneratorTest {
   @Test
   public void testAllPairsWithoutReplacement() {
     FluentIterable<KV<String, String>> pairs =
-        PairGenerator.<String, ImmutableList<String>>allPairs(
-            ImmutableList.of("one", "two", "three"), false, String.CASE_INSENSITIVE_ORDER);
+        PairGenerator.WITHOUT_REPLACEMENT.allPairs(ImmutableList.of("one", "two", "three"),
+            String.CASE_INSENSITIVE_ORDER);
     assertEquals(3, pairs.size());
-    Assert.assertThat(pairs,
+    assertThat(pairs,
         CoreMatchers.hasItems(KV.of("one", "two"), KV.of("one", "three"), KV.of("three", "two")));
   }
 }

--- a/src/test/java/com/google/cloud/genomics/dataflow/utils/PairGeneratorTest.java
+++ b/src/test/java/com/google/cloud/genomics/dataflow/utils/PairGeneratorTest.java
@@ -1,0 +1,36 @@
+package com.google.cloud.genomics.dataflow.utils;
+
+import static org.junit.Assert.*;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.google.cloud.dataflow.sdk.values.KV;
+import com.google.common.collect.FluentIterable;
+import com.google.common.collect.ImmutableList;
+
+public class PairGeneratorTest {
+
+  @Test
+  public void testAllPairsWithReplacement() {
+    FluentIterable<KV<String, String>> pairs =
+        PairGenerator.<String, ImmutableList<String>>allPairs(
+            ImmutableList.of("one", "two", "three"), true);
+    assertEquals(6, pairs.size());
+    Assert.assertThat(
+        pairs,
+        CoreMatchers.hasItems(KV.of("one", "one"), KV.of("one", "two"), KV.of("one", "three"),
+            KV.of("two", "two"), KV.of("two", "three"), KV.of("three", "three")));
+  }
+
+  @Test
+  public void testAllPairsWithoutReplacement() {
+    FluentIterable<KV<String, String>> pairs =
+        PairGenerator.<String, ImmutableList<String>>allPairs(
+            ImmutableList.of("one", "two", "three"), false);
+    assertEquals(3, pairs.size());
+    Assert.assertThat(pairs,
+        CoreMatchers.hasItems(KV.of("one", "two"), KV.of("one", "three"), KV.of("two", "three")));
+  }
+}

--- a/src/test/java/com/google/cloud/genomics/dataflow/utils/VariantUtilsTest.java
+++ b/src/test/java/com/google/cloud/genomics/dataflow/utils/VariantUtilsTest.java
@@ -13,7 +13,6 @@
  */
 package com.google.cloud.genomics.dataflow.utils;
 
-import static com.google.common.collect.Lists.newArrayList;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -29,12 +28,12 @@ import com.google.api.services.genomics.model.Call;
 @RunWith(JUnit4.class)
 public class VariantUtilsTest {
 
-  private List<String> emptyAlt = newArrayList();
+  private List<String> emptyAlt = Arrays.asList();
 
   @Test
   public void testIsVariant() {
     assertTrue(VariantUtils.isVariant(DataUtils.makeVariant("chr7", 200000, 200001, "A",
-        newArrayList("C"), (Call[]) null)));
+        Arrays.asList("C"), (Call[]) null)));
     // Block Records
     assertFalse(VariantUtils.isVariant(DataUtils.makeVariant("chr7", 200000, 200001, "A", emptyAlt,
         (Call[]) null)));
@@ -45,17 +44,17 @@ public class VariantUtilsTest {
   @Test
   public void testIsSNP() {
     assertTrue(VariantUtils.isSnp(DataUtils.makeVariant("chr7", 200000, 200001, "A",
-        newArrayList("C"), (Call[]) null)));
+        Arrays.asList("C"), (Call[]) null)));
     // Deletion
     assertFalse(VariantUtils.isSnp(DataUtils.makeVariant("chr7", 200000, 200001, "CA",
-        newArrayList("C"), (Call[]) null)));
+        Arrays.asList("C"), (Call[]) null)));
     // Insertion
     assertFalse(VariantUtils.isSnp(DataUtils.makeVariant("chr7", 200000, 200001, "C",
-        newArrayList("CA"), (Call[]) null)));
+        Arrays.asList("CA"), (Call[]) null)));
 
     // SNP and Insertion
     assertFalse(VariantUtils.isSnp(DataUtils.makeVariant("chr7", 200000, 200001, "C",
-        newArrayList("A", "CA"), (Call[]) null)));
+        Arrays.asList("A", "CA"), (Call[]) null)));
 
     // Block Records
     assertFalse(VariantUtils.isSnp(DataUtils.makeVariant("chr7", 200000, 200001, "A", emptyAlt,

--- a/src/test/java/com/google/cloud/genomics/dataflow/utils/VariantUtilsTest.java
+++ b/src/test/java/com/google/cloud/genomics/dataflow/utils/VariantUtilsTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2015 Google Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.genomics.dataflow.utils;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import com.google.api.services.genomics.model.Call;
+
+@RunWith(JUnit4.class)
+public class VariantUtilsTest {
+
+  private List<String> emptyAlt = newArrayList();
+
+  @Test
+  public void testIsVariant() {
+    assertTrue(VariantUtils.isVariant(DataUtils.makeVariant("chr7", 200000, 200001, "A",
+        newArrayList(Arrays.asList("C")), (Call[]) null)));
+    // Block Records
+    assertFalse(VariantUtils.isVariant(DataUtils.makeVariant("chr7", 200000, 200001, "A", emptyAlt,
+        (Call[]) null)));
+    assertFalse(VariantUtils.isVariant(DataUtils.makeVariant("chr7", 200000, 200001, "A", null,
+        (Call[]) null)));
+  }
+
+  @Test
+  public void testIsSNP() {
+    assertTrue(VariantUtils.isSnp(DataUtils.makeVariant("chr7", 200000, 200001, "A",
+        newArrayList(Arrays.asList("C")), (Call[]) null)));
+    // Deletion
+    assertFalse(VariantUtils.isSnp(DataUtils.makeVariant("chr7", 200000, 200001, "CA",
+        newArrayList(Arrays.asList("C")), (Call[]) null)));
+    // Insertion
+    assertFalse(VariantUtils.isSnp(DataUtils.makeVariant("chr7", 200000, 200001, "C",
+        newArrayList(Arrays.asList("CA")), (Call[]) null)));
+
+    // SNP and Insertion
+    assertFalse(VariantUtils.isSnp(DataUtils.makeVariant("chr7", 200000, 200001, "C",
+        newArrayList(Arrays.asList("A", "CA")), (Call[]) null)));
+
+    // Block Records
+    assertFalse(VariantUtils.isSnp(DataUtils.makeVariant("chr7", 200000, 200001, "A", emptyAlt,
+        (Call[]) null)));
+    assertFalse(VariantUtils.isSnp(DataUtils.makeVariant("chr7", 200000, 200001, "A", null,
+        (Call[]) null)));
+  }
+
+
+}

--- a/src/test/java/com/google/cloud/genomics/dataflow/utils/VariantUtilsTest.java
+++ b/src/test/java/com/google/cloud/genomics/dataflow/utils/VariantUtilsTest.java
@@ -34,7 +34,7 @@ public class VariantUtilsTest {
   @Test
   public void testIsVariant() {
     assertTrue(VariantUtils.isVariant(DataUtils.makeVariant("chr7", 200000, 200001, "A",
-        newArrayList(Arrays.asList("C")), (Call[]) null)));
+        newArrayList("C"), (Call[]) null)));
     // Block Records
     assertFalse(VariantUtils.isVariant(DataUtils.makeVariant("chr7", 200000, 200001, "A", emptyAlt,
         (Call[]) null)));
@@ -45,17 +45,17 @@ public class VariantUtilsTest {
   @Test
   public void testIsSNP() {
     assertTrue(VariantUtils.isSnp(DataUtils.makeVariant("chr7", 200000, 200001, "A",
-        newArrayList(Arrays.asList("C")), (Call[]) null)));
+        newArrayList("C"), (Call[]) null)));
     // Deletion
     assertFalse(VariantUtils.isSnp(DataUtils.makeVariant("chr7", 200000, 200001, "CA",
-        newArrayList(Arrays.asList("C")), (Call[]) null)));
+        newArrayList("C"), (Call[]) null)));
     // Insertion
     assertFalse(VariantUtils.isSnp(DataUtils.makeVariant("chr7", 200000, 200001, "C",
-        newArrayList(Arrays.asList("CA")), (Call[]) null)));
+        newArrayList("CA"), (Call[]) null)));
 
     // SNP and Insertion
     assertFalse(VariantUtils.isSnp(DataUtils.makeVariant("chr7", 200000, 200001, "C",
-        newArrayList(Arrays.asList("A", "CA")), (Call[]) null)));
+        newArrayList("A", "CA"), (Call[]) null)));
 
     // Block Records
     assertFalse(VariantUtils.isSnp(DataUtils.makeVariant("chr7", 200000, 200001, "A", emptyAlt,


### PR DESCRIPTION
Special handling is needed for data in gVCF format since analyses such as Identity by State must take into account reference-matches in addition to the variants (unlike other analyses such as PCA).

Fixes https://github.com/googlegenomics/dataflow-java/issues/21 and https://github.com/googlegenomics/dataflow-java/issues/24.