### PR TITLE
Sharded BAM reader and a sample read counting pipeline

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -196,6 +196,17 @@
       <version>2.5</version>
       <scope>runtime</scope>
     </dependency>
+    <dependency>
+      <groupId>com.github.samtools</groupId>
+      <artifactId>htsjdk</artifactId>
+      <version>1.128</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/src/main/java/com/google/cloud/genomics/dataflow/pipelines/CountReads.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/pipelines/CountReads.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright (C) 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.genomics.dataflow.pipelines;
+
+import static com.google.common.collect.Lists.newArrayList;
+
+import com.google.api.services.genomics.model.Read;
+import com.google.api.services.genomics.model.SearchReadsRequest;
+import com.google.cloud.dataflow.sdk.Pipeline;
+import com.google.cloud.dataflow.sdk.io.TextIO;
+import com.google.cloud.dataflow.sdk.options.Default;
+import com.google.cloud.dataflow.sdk.options.DefaultValueFactory;
+import com.google.cloud.dataflow.sdk.options.Description;
+import com.google.cloud.dataflow.sdk.options.PipelineOptions;
+import com.google.cloud.dataflow.sdk.options.PipelineOptionsFactory;
+import com.google.cloud.dataflow.sdk.transforms.Count;
+import com.google.cloud.dataflow.sdk.transforms.Create;
+import com.google.cloud.dataflow.sdk.transforms.DoFn;
+import com.google.cloud.dataflow.sdk.transforms.ParDo;
+import com.google.cloud.dataflow.sdk.values.PCollection;
+import com.google.cloud.genomics.dataflow.readers.ReadReader;
+import com.google.cloud.genomics.dataflow.readers.bam.ReadBAMTransform;
+import com.google.cloud.genomics.dataflow.readers.bam.Reader;
+import com.google.cloud.genomics.dataflow.utils.DataflowWorkarounds;
+import com.google.cloud.genomics.dataflow.utils.GCSOptions;
+import com.google.cloud.genomics.dataflow.utils.GenomicsDatasetOptions;
+import com.google.cloud.genomics.dataflow.utils.GenomicsOptions;
+import com.google.cloud.genomics.utils.Contig;
+import com.google.cloud.genomics.utils.GenomicsFactory;
+import com.google.cloud.genomics.utils.Paginator;
+import com.google.cloud.genomics.utils.Paginator.ShardBoundary;
+import com.google.common.base.Function;
+import com.google.common.base.Splitter;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+
+import org.codehaus.jackson.annotate.JsonIgnore;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.logging.Logger;
+
+/**
+ * Simple read counting pipeline, intended as an example for reading data from 
+ * APIs OR BAM files and invoking GATK tools.
+ */
+public class CountReads {
+  private static final Logger LOG = Logger.getLogger(CountReads.class.getName());
+  private static CountReadsOptions options;
+  private static Pipeline p;
+  private static GenomicsFactory.OfflineAuth auth;
+  public static interface CountReadsOptions extends GenomicsDatasetOptions, GCSOptions {
+    @Description("The ID of the Google Genomics ReadGroupSet this pipeline is working with. "
+        + "Default (empty) indicates all ReadGroupSets.")
+    @Default.String("")
+    String getReadGroupSetId();
+
+    void setReadGroupSetId(String readGroupSetId);
+
+    @Description("The path to the BAM file to get reads data from.")
+    @Default.String("")
+    String getBAMFilePath();
+
+    void setBAMFilePath(String filePath);
+    
+    @Description("Whether to shard BAM reading")
+    @Default.Boolean(true)
+    boolean getShardBAMReading();
+
+    void setShardBAMReading(boolean newValue);
+    
+    class ContigsFactory implements DefaultValueFactory<Iterable<Contig>> {
+      @Override
+      public Iterable<Contig> create(PipelineOptions options) {
+        return Iterables.transform(Splitter.on(",").split(options.as(CountReadsOptions.class).getReferences()),
+            new Function<String, Contig>() {
+              @Override
+              public Contig apply(String contigString) {
+                ArrayList<String> contigInfo = newArrayList(Splitter.on(":").split(contigString));
+                return new Contig(contigInfo.get(0), 
+                    contigInfo.size() > 1 ? 
+                        Long.valueOf(contigInfo.get(1)) : 0, 
+                    contigInfo.size() > 2 ?
+                        Long.valueOf(contigInfo.get(2)) : -1);
+              }
+            });
+      }
+    }
+    
+    @Default.InstanceFactory(ContigsFactory.class)
+    @JsonIgnore
+    Iterable<Contig> getContigs();
+    
+    void setContigs(Iterable<Contig> contigs);
+  }
+  
+  public static void main(String[] args) throws GeneralSecurityException, IOException {
+    options = PipelineOptionsFactory.fromArgs(args).withValidation().as(CountReadsOptions.class);
+    GenomicsOptions.Methods.validateOptions(options);
+    auth = GCSOptions.Methods.createGCSAuth(options);
+    p = Pipeline.create(options);
+    DataflowWorkarounds.registerGenomicsCoders(p);
+
+    PCollection<Read> reads = getReads();
+    PCollection<Long> readCount = reads.apply(Count.<Read>globally());
+    PCollection<String> readCountText = readCount.apply(ParDo.of(new DoFn<Long, String>() {
+      @Override
+      public void processElement(DoFn<Long, String>.ProcessContext c) throws Exception {
+        c.output(String.valueOf(c.element()));
+      }
+    }).named("toString"));
+    readCountText.apply(TextIO.Write.to(options.getOutput()).named("WriteOutput"));
+    p.run();
+  }
+
+  private static PCollection<Read> getReads() throws IOException {
+    if (!options.getBAMFilePath().isEmpty()) {
+      return getReadsFromBAMFile();
+    } 
+    if (!options.getReadGroupSetId().isEmpty()) {
+      return getReadsFromAPI();
+    }
+    throw new IOException("Either BAM file or ReadGroupSet must be specified");
+  }
+
+  private static PCollection<Read> getReadsFromAPI() {
+    List<SearchReadsRequest> requests = getReadRequests(options);
+    PCollection<SearchReadsRequest> readRequests =
+        DataflowWorkarounds.getPCollection(requests, p, options.getNumWorkers());
+    PCollection<Read> reads =
+        readRequests.apply(
+            ParDo.of(
+                new ReadReader(auth, Paginator.ShardBoundary.OVERLAPS))
+                  .named(ReadReader.class.getSimpleName()));
+    return reads;
+  }
+
+  private static List<SearchReadsRequest> getReadRequests(CountReadsOptions options) {
+    List<SearchReadsRequest> requests = Lists.newArrayList();
+    requests.add(new SearchReadsRequest()
+      .setReadGroupSetIds(
+          Collections.singletonList(options.getReadGroupSetId()))
+      .setReferenceName(options.getReferences())
+      .setPageSize(2048));
+
+    return requests;
+  }
+  
+  private static PCollection<Read> getReadsFromBAMFile() throws IOException {
+    LOG.info("getReadsFromBAMFile");
+
+    final Iterable<Contig> contigs = options.getContigs();
+        
+    if (options.getShardBAMReading()) {
+      return ReadBAMTransform.getReadsFromBAMFilesSharded(p, 
+          auth,
+          contigs, 
+          Collections.singletonList(options.getBAMFilePath()));
+    } else {  // For testing and comparing sharded vs. not sharded only
+      return p.apply(
+          Create.of(
+              Reader.readSequentiallyForTesting(
+                  GCSOptions.Methods.createStorageClient(options, auth),
+                  options.getBAMFilePath(),
+                  contigs.iterator().next())));
+    }
+  }
+}

--- a/src/main/java/com/google/cloud/genomics/dataflow/readers/bam/BAMIO.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/readers/bam/BAMIO.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.genomics.dataflow.readers.bam;
+
+import com.google.api.services.storage.Storage;
+
+import htsjdk.samtools.SamInputResource;
+import htsjdk.samtools.SamReader;
+import htsjdk.samtools.SamReaderFactory;
+import htsjdk.samtools.seekablestream.SeekableStream;
+
+import java.io.IOException;
+import java.util.logging.Logger;
+
+/**
+ * Utility methods for opening BAM files from GCS storage using HTSJDK.
+ * For sharding in pipelines we need access to the guts of BAM index,
+ * so openBAMAndExposeIndex provides a convenient way to get both SamReader and
+ * a stream for an index file.
+ */
+public class BAMIO {
+  public static class ReaderAndIndex {
+    public SamReader reader;
+    public SeekableStream index;
+  }
+  private static final Logger LOG = Logger.getLogger(BAMIO.class.getName());
+  
+  public static ReaderAndIndex openBAMAndExposeIndex(Storage.Objects storageClient,String gcsStoragePath) throws IOException {
+    ReaderAndIndex result = new ReaderAndIndex();
+    result.index = openIndexForPath(storageClient, gcsStoragePath);
+    result.reader = openBAMReader(
+        openBAMFile(storageClient, gcsStoragePath,result.index));
+    return result;
+  }
+  
+  public static SamReader openBAM(Storage.Objects storageClient,String gcsStoragePath) throws IOException {
+    return openBAMReader(openBAMFile(storageClient, gcsStoragePath,
+        openIndexForPath(storageClient, gcsStoragePath)));
+  }
+      
+  private static SeekableStream openIndexForPath(Storage.Objects storageClient,String gcsStoragePath) {
+    final String indexPath = gcsStoragePath + ".bai";
+    try {
+      return new SeekableGCSStream(storageClient, indexPath);
+    } catch (IOException ex) {
+      LOG.info("No index for " + indexPath);
+      // Ignore if there is no bai file
+    }
+    return null;
+  }
+  
+  private static SamInputResource openBAMFile(Storage.Objects storageClient, String gcsStoragePath, SeekableStream index) throws IOException {
+    SamInputResource samInputResource =
+        SamInputResource.of(new SeekableGCSStream(storageClient, gcsStoragePath));
+    if (index != null) {
+      samInputResource.index(index);
+    }
+
+    LOG.info("getReadsFromBAMFile - got input resources");
+    return samInputResource;
+  }
+  
+  private static SamReader openBAMReader(SamInputResource resource) {
+    SamReaderFactory samReaderFactory = SamReaderFactory.makeDefault()
+        .enable(SamReaderFactory.Option.CACHE_FILE_BASED_INDEXES);
+    final SamReader samReader = samReaderFactory.open(resource);
+    return samReader;
+  }
+}

--- a/src/main/java/com/google/cloud/genomics/dataflow/readers/bam/BAMShard.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/readers/bam/BAMShard.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.genomics.dataflow.readers.bam;
+
+import com.google.cloud.genomics.utils.Contig;
+import com.google.common.collect.Lists;
+
+import htsjdk.samtools.BAMFileIndexImpl;
+import htsjdk.samtools.Chunk;
+import htsjdk.samtools.SAMFileSpanImpl;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * A shard of BAM data we will create during sharding and then use to drive the reading.
+ * We use this class during shard generation, by iteratively building 
+ * a shard, extending it bin by bin (@see #addBin)
+ * At the end of the process, the shard is finalized (@see #finalize) 
+ * and SAMFileSpan that has all the chunks we want to read is produced.
+ */
+public class BAMShard implements Serializable {
+  public String file;
+  public SAMFileSpanImpl span;
+  public Contig contig;
+  public List<Chunk> chunks;
+  public long cachedSizeInBytes = -1;
+
+  /**
+   * Begins a new shard with an empty chunk list and a starting locus.
+   */
+  public BAMShard(String file, String referenceName, int firstLocus) {
+    this.file = file;
+    this.contig = new Contig(referenceName, firstLocus, -1);
+    this.chunks = Lists.newLinkedList();
+    this.span = null;
+  }
+  
+  /**
+   * Creates a shard with a known file span.
+   * Such shard is not expected to be extended and calling addBin or finalize on it will fail.
+   * This constructor is used for "degenerate" shards like unmapped reads or 
+   * all reads in cases where we don't have an index.
+   */
+  public BAMShard(String file, SAMFileSpanImpl span, Contig contig) {
+    this.file = file;
+    this.span = span;
+    this.contig = contig;
+    this.chunks = null;
+  }
+
+  /**
+   * Appends chunks from another bin to the list and moved the end position.
+   */
+  public void addBin(List<Chunk> chunksToAdd, int lastLocus) {
+    assert chunks != null;
+    contig = new Contig(contig.referenceName, contig.start, lastLocus);
+    chunks.addAll(chunksToAdd);
+    updateSpan();
+  }
+  
+  /**
+   * Generates a final list of chunks, now that we know the exact bounding loci
+   * for this shard. We get all chunks overlapping this loci, and then ask the index
+   * for the chunks overlapping them. 
+   */
+  public BAMShard finalize(BAMFileIndexImpl index, int lastLocus) {
+    if (lastLocus >= 0) {
+      contig = new Contig(contig.referenceName, contig.start, lastLocus);
+    }
+    this.chunks = index.getChunksOverlapping(contig.referenceName, 
+        (int)contig.start, (int)contig.end);
+    updateSpan();
+    return this;
+  }
+  
+  /**
+   * Updates the underlying file span by optimizing and coalescing the current chunk list.
+   */
+  private void updateSpan() {
+    span = new SAMFileSpanImpl(Chunk.optimizeChunkList(chunks, this.contig.start));
+    cachedSizeInBytes = -1;
+  }
+
+  public long sizeInLoci() {
+    return contig.end > 0 ? contig.end - contig.start : 0;
+  }
+  
+  public long approximateSizeInBytes() {
+    if (cachedSizeInBytes < 0) {
+      cachedSizeInBytes = span.approximateSizeInBytes();
+    }
+    return cachedSizeInBytes;
+  }
+
+  @Override
+  public String toString() {
+    return file + ": " + contig.toString() + ", locus size = " + sizeInLoci() + 
+        ", span size = " + approximateSizeInBytes();
+  }
+}

--- a/src/main/java/com/google/cloud/genomics/dataflow/readers/bam/ReadBAMTransform.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/readers/bam/ReadBAMTransform.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (C) 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.genomics.dataflow.readers.bam;
+
+import com.google.api.services.genomics.model.Read;
+import com.google.api.services.storage.Storage;
+import com.google.cloud.dataflow.sdk.Pipeline;
+import com.google.cloud.dataflow.sdk.coders.SerializableCoder;
+import com.google.cloud.dataflow.sdk.coders.StringUtf8Coder;
+import com.google.cloud.dataflow.sdk.transforms.Create;
+import com.google.cloud.dataflow.sdk.transforms.DoFn;
+import com.google.cloud.dataflow.sdk.transforms.PTransform;
+import com.google.cloud.dataflow.sdk.transforms.ParDo;
+import com.google.cloud.dataflow.sdk.transforms.View;
+import com.google.cloud.dataflow.sdk.values.PCollection;
+import com.google.cloud.dataflow.sdk.values.PCollectionTuple;
+import com.google.cloud.dataflow.sdk.values.PCollectionView;
+import com.google.cloud.dataflow.sdk.values.TupleTag;
+import com.google.cloud.genomics.dataflow.utils.GCSOptions;
+import com.google.cloud.genomics.utils.Contig;
+import com.google.cloud.genomics.utils.GenomicsFactory;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Takes a tuple of 2 collections: Contigs and BAM files and transforms them into
+ * a collection of reads by reading BAM files in a sharded manner.
+ */
+public class ReadBAMTransform extends PTransform<PCollectionTuple, PCollection<Read>> {
+  GenomicsFactory.OfflineAuth auth;
+  
+  public static TupleTag<Contig> CONTIGS_TAG = new TupleTag<>();
+  public static TupleTag<String> BAMS_TAG = new TupleTag<>();
+  
+  public static PCollection<Read> getReadsFromBAMFilesSharded(
+      Pipeline p, 
+      GenomicsFactory.OfflineAuth auth,
+      Iterable<Contig> contigs, List<String> BAMFiles) {
+      ReadBAMTransform readBAMSTransform = new ReadBAMTransform();
+      readBAMSTransform.setAuth(auth);
+      PCollectionTuple tuple = PCollectionTuple
+          .of(
+              ReadBAMTransform.BAMS_TAG, 
+                p.apply(
+                    Create.of(BAMFiles))
+                .setCoder(StringUtf8Coder.of()))
+         .and(ReadBAMTransform.CONTIGS_TAG, 
+             p.apply(
+                 Create.of(
+                     contigs))
+             .setCoder(SerializableCoder.of(Contig.class)));
+      return readBAMSTransform.apply(tuple);
+  }
+  
+  public static class ShardFn extends DoFn<String, BAMShard> {
+    GenomicsFactory.OfflineAuth auth;
+    PCollectionView<Iterable<Contig>, ?> contigsView;
+    Storage.Objects storage;
+    
+    public ShardFn(GenomicsFactory.OfflineAuth auth, PCollectionView<Iterable<Contig>, ?> contigsView) {
+      this.auth = auth;
+      this.contigsView = contigsView;
+    }
+    
+    @Override
+    public void startBundle(DoFn<String, BAMShard>.Context c) throws IOException {
+      storage = GCSOptions.Methods.createStorageClient(c, auth);
+    }
+    
+    @Override
+    public void processElement(ProcessContext c) throws java.lang.Exception {
+      (new Sharder(storage, c.element(), c.sideInput(contigsView), c))
+          .process();
+    }
+  }
+  
+  public static class ReadFn extends DoFn<BAMShard, Read> {
+    GenomicsFactory.OfflineAuth auth;
+    Storage.Objects storage;
+    
+    public ReadFn(GenomicsFactory.OfflineAuth auth) {
+      this.auth = auth;
+
+    }
+    
+    @Override
+    public void startBundle(DoFn<BAMShard, Read>.Context c) throws IOException {
+      storage = GCSOptions.Methods.createStorageClient(c, auth);
+    }
+    
+    @Override
+    public void processElement(ProcessContext c) throws java.lang.Exception {
+      (new Reader(storage, c.element(), c))
+          .process();
+    }
+  }
+  
+  
+  @Override
+  public PCollection<Read> apply(PCollectionTuple contigsAndBAMs) {
+
+    final PCollection<Contig> contigs = contigsAndBAMs.get(CONTIGS_TAG);
+    final PCollectionView<Iterable<Contig>, ?> contigsView =
+        contigs.apply(View.<Contig>asIterable());
+
+    final PCollection<String> BAMFileGCSPaths = contigsAndBAMs.get(BAMS_TAG);
+   
+    final PCollection<BAMShard> shards =
+        BAMFileGCSPaths.apply(ParDo
+            .withSideInputs(Arrays.asList(contigsView))
+            .of(new ShardFn(auth, contigsView)))
+              .setCoder(SerializableCoder.of(BAMShard.class));
+    
+    final PCollection<Read> reads = shards.apply(ParDo
+        .of(new ReadFn(auth)));
+
+    return reads;
+  }
+
+  public GenomicsFactory.OfflineAuth  getAuth() {
+    return auth;
+  }
+
+  public void setAuth(GenomicsFactory.OfflineAuth auth) {
+    this.auth = auth;
+  }
+}

--- a/src/main/java/com/google/cloud/genomics/dataflow/readers/bam/ReadConverter.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/readers/bam/ReadConverter.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.genomics.dataflow.readers.bam;
+
+import com.google.api.services.genomics.model.CigarUnit;
+import com.google.api.services.genomics.model.LinearAlignment;
+import com.google.api.services.genomics.model.Position;
+import com.google.api.services.genomics.model.Read;
+import com.google.common.base.Function;
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
+import com.google.common.collect.Lists;
+
+import htsjdk.samtools.CigarElement;
+import htsjdk.samtools.CigarOperator;
+import htsjdk.samtools.SAMException;
+import htsjdk.samtools.SAMRecord;
+import htsjdk.samtools.util.SequenceUtil;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Converts SAMRecords to Reads.
+ */
+public class ReadConverter {
+  static HashBiMap<String, String> CIGAR_OPERATIONS;
+  static BiMap<String, String> CIGAR_OPERATIONS_INV;
+
+  static {
+    CIGAR_OPERATIONS = HashBiMap.create();
+    CIGAR_OPERATIONS.put("ALIGNMENT_MATCH", "M");
+    CIGAR_OPERATIONS.put("CLIP_HARD", "H");
+    CIGAR_OPERATIONS.put("CLIP_SOFT", "S");
+    CIGAR_OPERATIONS.put("DELETE", "D");
+    CIGAR_OPERATIONS.put("INSERT", "I");
+    CIGAR_OPERATIONS.put("PAD", "P");
+    CIGAR_OPERATIONS.put("SEQUENCE_MATCH", "=");
+    CIGAR_OPERATIONS.put("SEQUENCE_MISMATCH", "X");
+    CIGAR_OPERATIONS.put("SKIP", "N");
+    CIGAR_OPERATIONS_INV = CIGAR_OPERATIONS.inverse();
+  }
+
+  /**
+   * Generates a Read from a SAMRecord. 
+   */
+  public static final Read makeRead(final SAMRecord record) {
+    Read read = new Read();
+    read.setId(record.getReadName()); // TODO: make more unique
+    read.setFragmentName(record.getReadName());
+    read.setReadGroupId(getAttr(record, "RG"));
+    read.setNumberReads(record.getReadPairedFlag() ? 1 : 2);
+    read.setProperPlacement(record.getReadPairedFlag() && record.getProperPairFlag());
+    if (!record.getReadUnmappedFlag() && record.getAlignmentStart() > 0) {
+      LinearAlignment alignment = new LinearAlignment();
+
+      Position position = new Position();
+      position.setPosition((long) record.getAlignmentStart() - 1);
+      position.setReferenceName(record.getReferenceName());
+      position.setReverseStrand(record.getReadNegativeStrandFlag());
+      alignment.setPosition(position);
+
+      alignment.setMappingQuality(record.getMappingQuality());
+
+      final String referenceSequence = (record.getAttribute("MD") != null) ? new String(
+          SequenceUtil.makeReferenceFromAlignment(record, true))
+          : null;
+      List<CigarUnit> cigar = Lists.transform(record.getCigar().getCigarElements(),
+          new Function<CigarElement, CigarUnit>() {
+            @Override
+            public CigarUnit apply(CigarElement c) {
+              CigarUnit u = new CigarUnit();
+              CigarOperator o = c.getOperator();
+              u.setOperation(CIGAR_OPERATIONS_INV.get(o.toString()));
+              u.setOperationLength((long) c.getLength());
+              if (referenceSequence != null && (u.getOperation().equals("SEQUENCE_MISMATCH")
+                  || u.getOperation().equals("DELETE"))) {
+                u.setReferenceSequence(referenceSequence);
+              }
+              return u;
+            }
+          });
+      alignment.setCigar(cigar);
+      read.setAlignment(alignment);
+    }
+    read.setDuplicateFragment(record.getDuplicateReadFlag());
+    read.setFragmentLength(record.getReadLength());
+    if (record.getReadPairedFlag()) {
+      if (record.getFirstOfPairFlag()) {
+        read.setReadNumber(0);
+      } else if (record.getSecondOfPairFlag()) {
+        read.setReadNumber(1);
+      }
+
+      if (!record.getMateUnmappedFlag()) {
+        Position matePosition = new Position();
+        matePosition.setPosition((long) record.getMateAlignmentStart() - 1);
+        matePosition.setReferenceName(record.getMateReferenceName());
+        matePosition.setReverseStrand(record.getMateNegativeStrandFlag());
+        read.setNextMatePosition(matePosition);
+      }
+    }
+    read.setFailedVendorQualityChecks(record.getReadFailsVendorQualityCheckFlag());
+    read.setSecondaryAlignment(record.getNotPrimaryAlignmentFlag());
+    read.setSupplementaryAlignment(record.getSupplementaryAlignmentFlag());
+    read.setAlignedSequence(record.getReadString());
+    byte[] baseQualities = record.getBaseQualities();
+    if (baseQualities.length > 0) {
+      List<Integer> readBaseQualities = new ArrayList<Integer>(baseQualities.length);
+      for (byte b : baseQualities) {
+        readBaseQualities.add(new Integer(b));
+      }
+      read.setAlignedQuality(readBaseQualities);
+    }
+
+    return read;
+  }
+
+  public static String getAttr(SAMRecord record, String attributeName) {
+    try {
+      return record.getStringAttribute(attributeName);
+    } catch (SAMException ex) {
+      return "";
+    }
+  }
+}

--- a/src/main/java/com/google/cloud/genomics/dataflow/readers/bam/Reader.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/readers/bam/Reader.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright (C) 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.genomics.dataflow.readers.bam;
+
+import com.google.api.services.genomics.model.Read;
+import com.google.api.services.storage.Storage;
+import com.google.api.services.storage.Storage.Objects;
+import com.google.cloud.dataflow.sdk.transforms.DoFn;
+import com.google.cloud.genomics.utils.Contig;
+import com.google.common.base.Stopwatch;
+
+import htsjdk.samtools.SAMRecord;
+import htsjdk.samtools.SAMRecordIterator;
+import htsjdk.samtools.SamReader;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+
+/**
+ * Get all the reads specified by a given shard from a given BAM file.
+ * Meant to be called from the DoFn processing the shard.
+ */
+public class Reader {
+  private static final Logger LOG = Logger.getLogger(Reader.class.getName());
+  
+  Storage.Objects storageClient;
+  BAMShard shard;
+  DoFn<BAMShard, Read>.ProcessContext c;
+  Stopwatch timer;
+  
+  SAMRecordIterator iterator;
+  boolean procesingUnmapped;
+  
+  int recordsBeforeStart = 0;
+  int recordsAfterEnd = 0;
+  int mismatchedSequence = 0;
+  int recordsProcessed = 0;
+  
+  public Reader(Objects storageClient, BAMShard shard, DoFn<BAMShard, Read>.ProcessContext c) {
+    super();
+    this.storageClient = storageClient;
+    this.shard = shard;
+    this.c = c;
+  }
+  
+  public void process() throws IOException {
+    timer = Stopwatch.createStarted();
+    openFile();
+    
+    while (iterator.hasNext()) {
+      processRecord(iterator.next());
+    }
+    
+    dumpStats();
+  }
+
+  void openFile() throws IOException {
+    LOG.info("Processing shard " + shard);
+    final SamReader reader = BAMIO.openBAM(storageClient, shard.file);
+    iterator = null;
+    procesingUnmapped = shard.contig.referenceName.equals("*");
+    if (reader.hasIndex() && reader.indexing() != null) {
+      if (procesingUnmapped) {
+        LOG.info("Processing unmapped");
+        iterator = reader.queryUnmapped();
+      } else if (shard.span != null) {
+        LOG.info("Processing span");
+        iterator = reader.indexing().iterator(shard.span);
+      } else if (shard.contig.referenceName != null && !shard.contig.referenceName.isEmpty()) {
+        LOG.info("Processing all bases for " + shard.contig.referenceName);
+        iterator = reader.query(shard.contig.referenceName, (int) shard.contig.start,
+            (int) shard.contig.end, false);
+      } 
+    }
+    if (iterator == null) {
+      LOG.info("Processing all reads");
+      iterator = reader.iterator();
+    }
+  }
+
+  boolean isWrongSequence(SAMRecord record) {
+    return (procesingUnmapped && !record.getReadUnmappedFlag()) ||
+        (!procesingUnmapped && shard.contig.referenceName != null && !shard.contig.referenceName.isEmpty()
+        && !shard.contig.referenceName.equals(record.getReferenceName()));
+  }
+  
+  void processRecord(SAMRecord record) {
+    if (isWrongSequence(record)) {
+      mismatchedSequence++;
+      return;
+    }
+    if (record.getAlignmentStart() < shard.contig.start) {
+      recordsBeforeStart++;
+      return;
+    }
+    if (record.getAlignmentStart() > shard.contig.end) {
+      recordsAfterEnd++;
+      return;
+    }
+    c.output(ReadConverter.makeRead(record));
+    recordsProcessed++;
+  }
+  
+  void dumpStats() {
+    timer.stop();
+    LOG.info("Processed " + recordsProcessed + 
+        " in " + timer + 
+        ". Speed: " + (recordsProcessed*1000)/timer.elapsed(TimeUnit.MILLISECONDS) + " reads/sec"
+        + ", skipped other sequences " + mismatchedSequence 
+        + ", skippedBefore " + recordsBeforeStart
+        + ", skipped after " + recordsAfterEnd);
+  }
+  
+  /**
+   * To compare how sharded reading works vs. plain HTSJDK sequential iteration,
+   * this method implements such iteration.
+   * This makes it easier to discover errors such as reads that are somehow
+   * skipped by a sharded approach.
+   */
+  public static Iterable<Read> readSequentiallyForTesting(Objects storageClient, String storagePath, Contig contig) throws IOException {
+    Stopwatch timer = Stopwatch.createStarted();
+    SamReader samReader = BAMIO.openBAM(storageClient, storagePath); 
+    SAMRecordIterator iterator =  samReader.queryOverlapping(contig.referenceName, 
+        (int) contig.start,
+        (int) contig.end);
+    List<Read> reads = new ArrayList<Read>(); 
+    
+    int recordsBeforeStart = 0;
+    int recordsAfterEnd = 0;
+    int mismatchedSequence = 0;
+    int recordsProcessed = 0;
+    while (iterator.hasNext()) {
+      SAMRecord record = iterator.next();
+      final boolean wrongSequence = !contig.referenceName.equals(record.getReferenceName());
+      
+      if (wrongSequence) {
+        mismatchedSequence++;
+        continue;
+      }
+      if (record.getAlignmentStart() < contig.start) {
+        recordsBeforeStart++;
+        continue;
+      }
+      if (record.getAlignmentStart() > contig.end) {
+        recordsAfterEnd++;
+        continue;
+      }
+      reads.add(ReadConverter.makeRead(record)); 
+      recordsProcessed++;
+    }
+    timer.stop();
+    LOG.info("NON SHARDED: Processed " + recordsProcessed + 
+        " in " + timer + 
+        ". Speed: " + (recordsProcessed*1000)/timer.elapsed(TimeUnit.MILLISECONDS) + " reads/sec"
+        + ", skipped other sequences " + mismatchedSequence 
+        + ", skippedBefore " + recordsBeforeStart
+        + ", skipped after " + recordsAfterEnd);
+    return reads;
+  }
+}

--- a/src/main/java/com/google/cloud/genomics/dataflow/readers/bam/SeekableGCSStream.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/readers/bam/SeekableGCSStream.java
@@ -1,0 +1,243 @@
+/*
+ * Copyright (C) 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.genomics.dataflow.readers.bam;
+
+import com.google.api.client.http.HttpResponse;
+import com.google.api.services.storage.Storage;
+import com.google.api.services.storage.Storage.Objects.Get;
+import com.google.api.services.storage.model.StorageObject;
+
+import htsjdk.samtools.seekablestream.SeekableStream;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.regex.Pattern;
+
+/**
+ * Adapter of GCS to look like HTSJDK SeekableStream so BAM readers
+ * can stream data from GCS.
+ * TODO: implement more sophisticated retries with backoff.
+ */
+public class SeekableGCSStream extends SeekableStream {
+  private static final Logger LOG = Logger.getLogger(SeekableGCSStream.class.getName());
+  
+  private static final Pattern SLASH = Pattern.compile("/");
+  private static final String GCS_PREFIX = "gs://";
+  private static final int MAX_RETRIES = 3;
+  private static final long RETRY_SLEEP_TIME_MSEC = 1000;
+  
+  private Storage.Objects client;
+  private StorageObject object;
+  private String name;
+  private Get get;
+  private InputStream stream = null;
+  private long size = -1;
+  private long position = -1;
+  private byte[] oneByte = new byte[1];
+  private boolean atEof = false;
+  
+  public SeekableGCSStream(Storage.Objects client, String name) throws IOException {
+    LOG.info("Creating SeekableGCSStream: " + name);
+    this.client = client;
+    object = uriToStorageObject(name);
+    get = this.client.get(object.getBucket(), object.getName());
+    seek(0);
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (stream != null) {
+      stream.close();
+      stream = null;
+    }
+  }
+
+  @Override
+  public boolean eof() throws IOException {
+    return atEof;
+  }
+
+  @Override
+  public String getSource() {
+    return name;
+  }
+
+  @Override
+  public long length() {
+    return size;
+  }
+
+  @Override
+  public long position() throws IOException {
+    return position;
+  }
+  
+  @Override
+  public int read() throws IOException {
+    final int bytesRead = read(oneByte, 0, 1);
+    return bytesRead==1 ? oneByte[0] : -1;
+  }
+
+  @Override
+  public void seek(long arg0) throws IOException {
+    if (arg0 == position) {
+      return;
+    }
+    validatePosition(arg0);
+    position = arg0;
+    openStream();
+  }
+  
+  protected void openStream()
+      throws IOException {
+    if (LOG.isLoggable(Level.FINEST)) {
+      LOG.finest("openStream: " + position);
+    }
+    try {
+      close();
+    } catch (Exception ex) {
+      // Ignore problems in closing the old stream
+    }
+    validatePosition(position);
+    get.getRequestHeaders()
+        .setRange(String.format("bytes=%d-", position));
+    HttpResponse response;
+    try {
+      response = get.executeMedia();
+    } catch (IOException e) {
+      String msg = String.format("Error reading %s at position %d",
+          name, position);
+      atEof = true;
+      throw new IOException(msg, e);
+    }
+    String contentRange = response.getHeaders().getContentRange();
+    if (response.getHeaders().getContentLength() != null) {
+      size = response.getHeaders().getContentLength() + position;
+    } else if (contentRange != null) {
+      String sizeStr = SLASH.split(contentRange)[1];
+      try {
+        size = Long.parseLong(sizeStr);
+      } catch (NumberFormatException e) {
+        throw new IOException(
+            "Could not determine size from response from Content-Range: " + contentRange, e);
+      }
+    } else {
+      throw new IOException("Could not determine size of response");
+    }
+    if (LOG.isLoggable(Level.FINEST)) {
+      LOG.finest("stream size=" + size);
+    }
+    atEof = size == 0;
+    stream = response.getContent();
+  }
+  
+  protected void validatePosition(long newPosition) {
+    if (newPosition < 0) {
+      throw new IllegalArgumentException(
+          String.format("Invalid seek offset: position value (%d) must be >= 0", newPosition));
+    }
+
+    if ((size >= 0) && (newPosition >= size)) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Invalid seek offset: position value (%d) must be between 0 and %d",
+              newPosition, size));
+    }
+  }
+  
+  @Override
+  public int read(byte[] buf, int offset, int len)
+      throws IOException {
+    if (LOG.isLoggable(Level.FINEST)) {
+      LOG.finest("Read at offset " + offset + " length " + len);
+    }
+    if (len == 0 || offset >= len) {
+      return 0;
+    }
+
+    int totalBytesRead = 0;
+    int retriesAttempted = 0;
+
+    do {
+      try {
+        final int numBytesRead = stream.read(buf, 
+            offset + totalBytesRead, len - totalBytesRead);
+        if (LOG.isLoggable(Level.FINEST)) {
+          LOG.finest("Read returned: " + numBytesRead);
+        }
+        if (numBytesRead < 0) {
+          atEof = true;
+          break;
+        }
+        totalBytesRead += numBytesRead;
+        position += numBytesRead;
+
+        retriesAttempted = 0;
+      } catch (IOException ioe) {
+        if (retriesAttempted == MAX_RETRIES) {
+          LOG.warning(
+              String.format("Already attempted max of %d retries while reading '%s'; throwing exception.",
+              retriesAttempted, name));
+          throw ioe;
+        } else {
+          ++retriesAttempted;
+          LOG.warning(String.format("Got exception: %s while reading '%s'; retry # %d. Sleeping...",
+              ioe.getMessage(), name, retriesAttempted));
+
+          try {
+            // TODO: implement backoff logic instead of simplistic static sleep interval
+            Thread.sleep(RETRY_SLEEP_TIME_MSEC);
+          } catch (InterruptedException ie) {
+            LOG.warning(String.format("Interrupted while sleeping before retry. Giving up "
+                + "after %d retries for '%s'", retriesAttempted, name));
+            ioe.addSuppressed(ie);
+            throw ioe;
+          }
+          LOG.info(String.format("Done sleeping before retry for '%s'; retry # %d.",
+              name, retriesAttempted));
+
+          openStream();
+        }
+      }
+    } while (totalBytesRead < len);
+
+    final int retVal = (totalBytesRead == 0) ? -1 : totalBytesRead;
+    if (LOG.isLoggable(Level.FINEST)) {
+      LOG.finest("Read result " + retVal);
+    }
+    return retVal;
+  }
+  
+  private static StorageObject uriToStorageObject(String uri) throws IOException {
+    StorageObject object = new StorageObject();
+    if (uri.startsWith(GCS_PREFIX)) {
+      uri = uri.substring(GCS_PREFIX.length());
+    } else {
+      throw new IOException("Invalid GCS path (does not start with gs://): " + uri);
+    }
+    int slashPos = uri.indexOf("/");
+    if (slashPos > 0) {
+      object.setBucket(uri.substring(0, slashPos));
+      object.setName(uri.substring(slashPos + 1));
+      LOG.info("uriToStorageObject " + uri + "=" + object.getBucket() + ":" + object.getName());
+    } else {
+      throw new IOException("Invalid GCS path (does not have bucket/name form): " + uri);
+    }
+    return object;
+  }
+}

--- a/src/main/java/com/google/cloud/genomics/dataflow/readers/bam/Sharder.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/readers/bam/Sharder.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright (C) 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.genomics.dataflow.readers.bam;
+
+import com.google.api.services.storage.Storage;
+import com.google.api.services.storage.Storage.Objects;
+import com.google.cloud.dataflow.sdk.transforms.DoFn;
+import com.google.cloud.genomics.utils.Contig;
+import com.google.common.collect.Maps;
+
+import htsjdk.samtools.BAMFileIndexImpl;
+import htsjdk.samtools.Bin;
+import htsjdk.samtools.Chunk;
+import htsjdk.samtools.GenomicIndexUtil;
+import htsjdk.samtools.SAMFileHeader;
+import htsjdk.samtools.SAMSequenceRecord;
+import htsjdk.samtools.SamReader;
+import htsjdk.samtools.seekablestream.SeekableStream;
+import htsjdk.samtools.util.IOUtil;
+
+import java.io.IOException;
+import java.util.BitSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Generates shards for a given BAM file and a desired set of contigs.
+ */
+public class Sharder {
+  private static final Logger LOG = Logger.getLogger(Sharder.class.getName());
+
+
+  Storage.Objects storageClient;
+  String filePath; 
+  Iterable<Contig> requestedContigs;
+  DoFn<String, BAMShard>.ProcessContext c;
+  final ShardingPolicy shardingPolicy = ShardingPolicy.BYTE_SIZE_POLICY;
+  
+  SamReader reader;
+  SeekableStream indexStream;
+  SAMFileHeader header;
+  BAMFileIndexImpl index;
+  
+  boolean allReferences;
+  boolean hasIndex;
+  HashMap<String, Contig> contigsByReference;
+  
+  public Sharder(Objects storageClient, String filePath, Iterable<Contig> requestedContigs,
+      DoFn<String, BAMShard>.ProcessContext c) {
+    super();
+    this.storageClient = storageClient;
+    this.filePath = filePath;
+    this.requestedContigs = requestedContigs;
+    this.c = c;
+  }
+
+  public void process() throws IOException {
+    LOG.info("Processing BAM file " + filePath);
+        
+    openFile();
+    processHeader();
+ 
+    for (SAMSequenceRecord sequenceRecord : header.getSequenceDictionary().getSequences()) {
+      final Contig contig = desiredContigForReference(sequenceRecord);
+      if (contig == null) {
+        continue;
+      } else if (!hasIndex) {
+        // No index, so create a shard over all BAM file and pass a contig restrict.
+        // We will iterate over all reads for this reference and skip the ones outside contig.
+        LOG.info("No index: outputting shard for " + contig);
+        c.output(new BAMShard(filePath, null, contig));
+        continue;
+      }
+      createShardsForReference(sequenceRecord, contig);
+    }
+    if (index != null) {
+      index.close();
+    }
+  }
+  
+  void openFile() throws IOException {
+    final BAMIO.ReaderAndIndex r = BAMIO.openBAMAndExposeIndex(storageClient, filePath);
+    reader = r.reader;
+    indexStream = r.index;
+    header = reader.getFileHeader();
+    hasIndex = reader.hasIndex() && reader.indexing().hasBrowseableIndex();
+    LOG.info("Has index = " + hasIndex);
+    if (hasIndex) {
+      index = new BAMFileIndexImpl(
+          IOUtil.maybeBufferedSeekableStream(indexStream),header.getSequenceDictionary());
+    } else {
+      index = null;
+    }
+  }
+  
+  void processHeader() {
+    contigsByReference = Maps.newHashMap();
+    for (Contig contig : requestedContigs) {
+      contigsByReference.put(contig.referenceName != null ? contig.referenceName : "", contig);
+    }
+    if (contigsByReference.size() == 0 || contigsByReference.containsKey("*")) {
+      LOG.info("Outputting unmapped reads shard ");
+      c.output(new BAMShard(filePath, null, new Contig("*", 0, -1)));
+    }
+    final boolean allReferences =
+        contigsByReference.size() == 0 || contigsByReference.containsKey("");
+    LOG.info("All references = " + allReferences);
+    LOG.info("BAM has index = " + reader.hasIndex());
+    LOG.info("BAM has browseable index = " + reader.indexing().hasBrowseableIndex());
+    LOG.info("Class for index = " + reader.indexing().getIndex().getClass().getName());  
+  }
+  
+  Contig desiredContigForReference(SAMSequenceRecord reference) {
+    Contig contig = contigsByReference.get(reference.getSequenceName());
+    if (contig == null) {
+      if (allReferences) {
+        contig = new Contig(reference.getSequenceName(), 0, -1);
+      } else {
+        LOG.fine("No contig requested for reference " + reference.getSequenceName());
+        return null;
+      }
+    }
+    assert contig != null;
+    if (contig.end <= 0) {
+      contig = new Contig(contig.referenceName, contig.start, reference.getSequenceLength());
+      LOG.info("Updated length for contig for " + contig.referenceName + " to " + contig.end);
+    }
+    return contig;
+  }
+  
+  void createShardsForReference(SAMSequenceRecord reference, Contig contig) {
+    final BitSet overlappingBins = GenomicIndexUtil.regionToBins(
+        (int) contig.start, (int) contig.end);
+    if (overlappingBins == null) {
+      LOG.warning("No overlapping bins for " + contig.start + ":" + contig.end);
+      return;
+    }
+    
+    BAMShard currentShard = null;
+    for (int binIndex = overlappingBins.nextSetBit(0); binIndex >= 0; binIndex = overlappingBins.nextSetBit(binIndex + 1)) {
+      final Bin bin = index.getBinData(reference.getSequenceIndex(), binIndex);
+      if (bin == null) {
+        continue;
+      }
+      if (LOG.isLoggable(Level.FINE)) {
+        LOG.fine("Processing bin " + index.getFirstLocusInBin(bin) + "-"
+            + index.getLastLocusInBin(bin));
+      }
+      
+      if (index.getLevelForBin(bin) != (GenomicIndexUtil.LEVEL_STARTS.length - 1)) {
+        if (LOG.isLoggable(Level.FINEST)) {
+          LOG.finest("Skipping - not lowest");
+        }
+        continue; 
+        // Skip non-lowest level bins
+        // Its ok to skip higher level bins
+        // because in BAMShard#finalize we
+        // will get all chunks overlapping a genomic region that
+        // we end up having for the shard, so we will not
+        // miss any reads on the boundary.
+      }
+      final List<Chunk> chunksInBin = bin.getChunkList();
+      if (chunksInBin.isEmpty()) {
+        if (LOG.isLoggable(Level.FINEST)) {
+          LOG.finest("Skipping - empty");
+        }
+        continue; // Skip empty bins
+      }
+
+      if (currentShard == null) {
+        if (LOG.isLoggable(Level.FINE)) {
+          LOG.fine("Creating shard starting from " + index.getFirstLocusInBin(bin));
+        }
+        currentShard = new BAMShard(filePath, reference.getSequenceName(),
+            index.getFirstLocusInBin(bin));
+      }
+      currentShard.addBin(chunksInBin, index.getLastLocusInBin(bin));
+      if (LOG.isLoggable(Level.FINE)) {
+        LOG.fine("Extending the shard  to " + index.getLastLocusInBin(bin));
+      }
+
+      if (shardingPolicy.shardBigEnough(currentShard)) {
+        LOG.info("Shard size is big enough to finalize: " + 
+            currentShard.sizeInLoci() + ", " + currentShard.approximateSizeInBytes() + " bytes");
+        c.output(currentShard.finalize(index, -1));
+        currentShard = null;
+      }
+    }
+    if (currentShard != null) {
+      LOG.info("Outputting last shard of size " + 
+          currentShard.sizeInLoci() + ", " + currentShard.approximateSizeInBytes() + " bytes");
+      c.output(currentShard.finalize(index, (int)contig.end));
+    }
+  }
+}

--- a/src/main/java/com/google/cloud/genomics/dataflow/readers/bam/ShardingPolicy.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/readers/bam/ShardingPolicy.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.genomics.dataflow.readers.bam;
+
+/**
+ * Different sharding policies and constants governing
+ * how we slice the data in BAM file.
+ */
+public interface ShardingPolicy  {
+  /**
+   * Decides whether a shard we are growing is large enough to be finalized
+   * and submitted for processing.
+   */
+  public boolean shardBigEnough(BAMShard shard);
+  
+  static final int MAX_BYTES_PER_SHARD = 10*1024*1024;    // 100MB
+  public static ShardingPolicy BYTE_SIZE_POLICY =
+   new ShardingPolicy() {
+      @Override
+      public boolean shardBigEnough(BAMShard shard) {
+        return shard.approximateSizeInBytes() > MAX_BYTES_PER_SHARD;
+      }
+    };
+  
+  static final int MAX_BASE_PAIRS_PER_SHARD = 100000;
+  public static ShardingPolicy LOCI_SIZE_POLICY = 
+    new ShardingPolicy() {
+      @Override
+      public boolean shardBigEnough(BAMShard shard) {
+        return shard.sizeInLoci() > MAX_BASE_PAIRS_PER_SHARD;
+      }
+    };
+}
+

--- a/src/main/java/com/google/cloud/genomics/dataflow/utils/GCSOptions.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/utils/GCSOptions.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.genomics.dataflow.utils;
+
+import com.google.api.client.googleapis.util.Utils;
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.services.dataflow.DataflowScopes;
+import com.google.api.services.genomics.GenomicsScopes;
+import com.google.api.services.storage.Storage;
+import com.google.api.services.storage.StorageScopes;
+import com.google.cloud.dataflow.sdk.options.Default;
+import com.google.cloud.dataflow.sdk.options.DefaultValueFactory;
+import com.google.cloud.dataflow.sdk.options.PipelineOptions;
+import com.google.cloud.dataflow.sdk.transforms.DoFn;
+import com.google.cloud.genomics.utils.GenomicsFactory;
+import com.google.common.collect.ImmutableList;
+
+import org.codehaus.jackson.annotate.JsonIgnore;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.logging.Logger;
+
+/**
+ * Options for pipelines that need to access GCS storage.
+ * Users must call Methods.initialize to get the credentials set up.
+ * getStorageClient() provides the GCS storage client.
+ */
+public interface GCSOptions extends GenomicsOptions {
+  class HttpTransportFactory implements DefaultValueFactory<HttpTransport> {
+    @Override
+    public HttpTransport create(PipelineOptions options) {
+      return Utils.getDefaultTransport();
+    }
+  }
+  
+  @Default.InstanceFactory(HttpTransportFactory.class)
+  @JsonIgnore
+  HttpTransport getTransport();
+
+  void setTransport(HttpTransport transport);
+
+  class JsonFactoryFactory implements DefaultValueFactory<JsonFactory> {
+    @Override
+    public JsonFactory create(PipelineOptions options) {
+      return Utils.getDefaultJsonFactory();
+    }
+  }
+  
+  @Default.InstanceFactory(JsonFactoryFactory.class)
+  @JsonIgnore
+  JsonFactory getJsonFactory();
+
+  void setJsonFactory(JsonFactory jsonFactory);
+
+  
+  class ScopesFactory implements DefaultValueFactory<List<String>> {
+    @Override
+    public List<String> create(PipelineOptions options) {
+      return ImmutableList.<String>builder()
+        .add(DataflowScopes.USERINFO_EMAIL)
+        .add(GenomicsScopes.GENOMICS)
+        .add(StorageScopes.DEVSTORAGE_READ_WRITE)
+        .build();
+    }
+  }
+  
+  @Default.InstanceFactory(ScopesFactory.class)
+  @JsonIgnore
+  List<String> getScopes();
+
+  void setScopes(List<String> scopes);
+  
+  class GenomicsFactoryFactory implements DefaultValueFactory<GenomicsFactory> {
+    @Override
+    public GenomicsFactory create(PipelineOptions options) {
+      GCSOptions gcsOptions = options.as(GCSOptions.class);
+      try {
+        return GenomicsFactory
+          .builder(gcsOptions.getAppName())
+            .setScopes(gcsOptions.getScopes())
+            .setHttpTransport(gcsOptions.getTransport())
+            .setJsonFactory(gcsOptions.getJsonFactory())
+            .build();
+      } catch (Exception ex) {
+          throw new RuntimeException(ex);
+      }
+    }
+  }
+  
+  @Default.InstanceFactory(GenomicsFactoryFactory.class)
+  @JsonIgnore
+  GenomicsFactory getGenomicsFactory();
+  
+  void setGenomicsFactory(GenomicsFactory factory);
+  
+  class Methods {
+    private static final Logger LOG = Logger.getLogger(GCSOptions.class.getName());
+    private Methods() {
+    }
+    
+    public static GenomicsFactory.OfflineAuth createGCSAuth(GCSOptions options)
+      throws IOException {
+      return options
+              .getGenomicsFactory()
+              .getOfflineAuth(null, options.getGenomicsSecretsFile());
+    }
+    
+    public static Storage.Objects createStorageClient(
+        DoFn<?, ?>.Context context, GenomicsFactory.OfflineAuth auth) throws IOException {
+      final GCSOptions gcsOptions =
+          context.getPipelineOptions().as(GCSOptions.class);
+      return createStorageClient(gcsOptions, auth);
+    }
+    
+    public static Storage.Objects createStorageClient(GCSOptions gcsOptions,
+        GenomicsFactory.OfflineAuth auth) throws IOException {
+      LOG.info("Creating storgae client for " + auth.applicationName);
+      final Storage.Builder storageBuilder = new Storage.Builder(
+          gcsOptions.getTransport(),
+          gcsOptions.getJsonFactory(),
+          null);
+      
+      return auth
+          .setupAuthentication(gcsOptions.getGenomicsFactory(), storageBuilder)
+          .build()
+            .objects();
+      }
+    
+  }
+}

--- a/src/main/java/htsjdk/samtools/BAMFileIndexImpl.java
+++ b/src/main/java/htsjdk/samtools/BAMFileIndexImpl.java
@@ -1,0 +1,31 @@
+package htsjdk.samtools;
+
+import java.util.List;
+
+import htsjdk.samtools.seekablestream.SeekableStream;
+
+/**
+ * Dealing with visibility constraints of classes in HTSJDK we need to use.
+ * Exposes BAM Index bin data we need for sharding calculations.
+ */
+public class BAMFileIndexImpl extends CachingBAMFileIndex {
+  private SAMSequenceDictionary mBamDictionary;
+  public BAMFileIndexImpl(SeekableStream stream, SAMSequenceDictionary dict) {
+    super(stream, dict);
+    mBamDictionary = dict;
+  }
+  
+  public Bin getBinData(final int referenceIndex, final int binIndex) {
+    final BAMIndexContent queryResults = getQueryResults(referenceIndex);
+
+    if(queryResults == null)
+        return null;
+    return queryResults.getBins().getBin(binIndex);
+  }
+  
+  public List<Chunk> getChunksOverlapping(final String reference, final int startPos, final int endPos) {
+    int referenceIndex = mBamDictionary.getSequence(reference).getSequenceIndex();
+    final BAMIndexContent queryResults = getQueryResults(referenceIndex);
+    return queryResults.getChunksOverlapping(startPos, endPos);
+  }
+}

--- a/src/main/java/htsjdk/samtools/SAMFileSpanImpl.java
+++ b/src/main/java/htsjdk/samtools/SAMFileSpanImpl.java
@@ -1,0 +1,35 @@
+package htsjdk.samtools;
+
+import java.util.List;
+
+/**
+ * Dealing with visibility constraints of classes in HTSJDK we need to use.
+ * Allows construction of SAMFileSpan objects and exposes a method
+ * to calculate approximate size of span in bytes.
+ */
+public class SAMFileSpanImpl extends BAMFileSpan {
+	private static final long serialVersionUID = 1L;
+	private long cachedSize = -1;
+	
+	public SAMFileSpanImpl() {
+		super();
+	}
+	
+	public SAMFileSpanImpl(final List<Chunk> chunks) {
+		super(chunks);
+	}
+	
+	private static final double AVERAGE_BAM_COMPRESSION_RATIO = 0.39;
+	
+	public long approximateSizeInBytes() {
+	  if (cachedSize < 0) {
+    	  cachedSize = 0;
+    	  for (Chunk chunk : getChunks()) {
+    	    final long chunkSpan = Math.round(((chunk.getChunkEnd()>>16)-(chunk.getChunkStart()>>16))/AVERAGE_BAM_COMPRESSION_RATIO);
+            final int offsetSpan = (int)((chunk.getChunkEnd()&0xFFFF)-(chunk.getChunkStart()&0xFFFF));
+            cachedSize += chunkSpan + offsetSpan;
+    	  }
+	  }
+      return cachedSize;
+	}
+}

--- a/src/main/scripts/count_reads.sh
+++ b/src/main/scripts/count_reads.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Runs CountReads pipeline locally and in the cloud (pass "cloud" as a param).
+# Assumes the script is run from dataflow-java directory.
+# Assumes client_secrets.json is located in a parent directory of dataflow-java.
+
+JAR=target/google-genomics-dataflow-v1beta2-0.2-SNAPSHOT.jar
+CLIENT_SECRETS=$(readlink -f ../client_secrets.json)
+# Assumes the following variables are set
+# Please set them before calling or edit this file and set them.
+# PROJECT_ID=cloud-project-name
+# OUTPUT=gs://test/df/count_reads/output/count.txt
+# STAGING=gs://test/df/count_reads/staging
+# DATASET_ID=15448427866823121459
+# READGROUPSET_ID=CK256frpGBD44IWHwLP22R4
+# DESIRED_CONTIGS=20:56311809:62603264
+# BAM_FILE_PATH=gs://test/NA12878.chrom20.ILLUMINA.bwa.CEU.exome.20121211.bam
+
+if [ "$1" = "bam" ]; then
+ bam_argument="--BAMFilePath=$BAM_FILE_PATH"
+fi
+if [ "$2" = "cloud" ]; then
+  additional_arguments="--stagingLocation=${STAGING} --numWorkers=1 --runner=BlockingDataflowPipelineRunner"
+else
+  additional_arguments="--numWorkers=1"
+fi
+
+echo Running: $JAR
+echo Client secrets in: $CLIENT_SECRETS
+echo Output in: $OUTPUT
+echo Additional arguments: $additional_arguments
+
+java -XX:MaxPermSize=512m -Xms2g -Xmx3g -cp $JAR \
+com.google.cloud.genomics.dataflow.pipelines.CountReads \
+--project=$PROJECT_ID \
+--output=$OUTPUT \
+--genomicsSecretsFile=$CLIENT_SECRETS \
+--datasetId=$DATASET_ID \
+--readGroupSetId=$READGROUPSET_ID \
+--references=$DESIRED_CONTIGS \
+$additional_arguments \
+$bam_argument

--- a/src/test/java/com/google/cloud/genomics/dataflow/readers/bam/BAMShardTest.java
+++ b/src/test/java/com/google/cloud/genomics/dataflow/readers/bam/BAMShardTest.java
@@ -1,0 +1,26 @@
+package com.google.cloud.genomics.dataflow.readers.bam;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.junit.Test;
+
+import htsjdk.samtools.BAMFileIndexImpl;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collections;
+
+import htsjdk.samtools.Chunk;
+
+@RunWith(JUnit4.class)
+public class BAMShardTest {
+  @Test
+  public void testShardGrowth() {
+    BAMShard shard = new BAMShard("f","chr20",1);
+    Chunk chunk = new Chunk(1,20);
+    shard.addBin(Collections.singletonList(chunk),10);
+    assertEquals(9, shard.sizeInLoci());
+    assertEquals(19, shard.approximateSizeInBytes());
+  }
+}

--- a/src/test/java/com/google/cloud/genomics/dataflow/readers/bam/ReadConverterTest.java
+++ b/src/test/java/com/google/cloud/genomics/dataflow/readers/bam/ReadConverterTest.java
@@ -1,0 +1,45 @@
+package com.google.cloud.genomics.dataflow.readers.bam;
+
+import com.google.api.services.genomics.model.Read;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import htsjdk.samtools.SAMRecord;
+
+@RunWith(JUnit4.class)
+public class ReadConverterTest {
+  @Test
+  public void testConversion() {
+    SAMRecord record = new SAMRecord(null);
+    record.setReferenceName("chr20");
+    record.setAlignmentStart(1);
+    record.setCigarString(String.format("%dM", 10));
+    record.setMateReferenceName("chr20");
+    record.setMateAlignmentStart(100);
+    record.setReadPairedFlag(true);
+    record.setFirstOfPairFlag(true);
+    record.setMateNegativeStrandFlag(true);
+    
+    Read read = ReadConverter.makeRead(record);
+    assertEquals((long)0, (long)read.getAlignment().getPosition().getPosition());
+    assertEquals((long)1, (long)read.getAlignment().getCigar().size());
+    assertEquals("chr20", read.getAlignment().getPosition().getReferenceName());
+    assertEquals((int)0, (int)read.getReadNumber());
+    assertEquals((long)99, (long)read.getNextMatePosition().getPosition());
+    assertEquals("chr20", read.getNextMatePosition().getReferenceName());
+    assertEquals((Boolean)true, read.getNextMatePosition().getReverseStrand());
+  }
+  
+}


### PR DESCRIPTION
@wbrockman @jean-philippe-martin @dionloy - here is the first version of the sharded BAM reader. Works in the cloud with a workaround for credentials factory.
- Most of the common files are under readers/bam.
- The CountReads pipeline is there as an example of using the reader. It can read from the API or BAM file. 
- I added a GCSOptions class to capture what is needed to access GCS.
- Some files added under htsjdk/samtools because I needed to deal with visibility restrictions in HTSJDK classes (not pretty but fwiw GATK code base does the same).
Also added dependency on HTSJDK in pom.xml
