### PR TITLE
fixed CountReads

### DIFF
--- a/src/main/java/com/google/cloud/genomics/dataflow/pipelines/CountReads.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/pipelines/CountReads.java
@@ -17,12 +17,12 @@ import static com.google.common.collect.Lists.newArrayList;
 
 import com.google.api.services.genomics.model.Read;
 import com.google.api.services.genomics.model.SearchReadsRequest;
+import com.google.api.services.storage.Storage;
+import com.google.api.services.storage.model.StorageObject;
 import com.google.cloud.dataflow.sdk.Pipeline;
 import com.google.cloud.dataflow.sdk.io.TextIO;
 import com.google.cloud.dataflow.sdk.options.Default;
-import com.google.cloud.dataflow.sdk.options.DefaultValueFactory;
 import com.google.cloud.dataflow.sdk.options.Description;
-import com.google.cloud.dataflow.sdk.options.PipelineOptions;
 import com.google.cloud.dataflow.sdk.options.PipelineOptionsFactory;
 import com.google.cloud.dataflow.sdk.transforms.Count;
 import com.google.cloud.dataflow.sdk.transforms.Create;
@@ -33,38 +33,51 @@ import com.google.cloud.genomics.dataflow.readers.ReadReader;
 import com.google.cloud.genomics.dataflow.readers.bam.ReadBAMTransform;
 import com.google.cloud.genomics.dataflow.readers.bam.Reader;
 import com.google.cloud.genomics.dataflow.utils.DataflowWorkarounds;
+import com.google.cloud.genomics.dataflow.utils.GCSFilename;
 import com.google.cloud.genomics.dataflow.utils.GCSOptions;
 import com.google.cloud.genomics.dataflow.utils.GenomicsDatasetOptions;
 import com.google.cloud.genomics.dataflow.utils.GenomicsOptions;
 import com.google.cloud.genomics.utils.Contig;
 import com.google.cloud.genomics.utils.GenomicsFactory;
 import com.google.cloud.genomics.utils.Paginator;
-import com.google.cloud.genomics.utils.Paginator.ShardBoundary;
 import com.google.common.base.Function;
 import com.google.common.base.Splitter;
+import com.google.common.base.Strings;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
-
-import org.codehaus.jackson.annotate.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import java.io.IOException;
+import java.math.BigInteger;
 import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.logging.Logger;
 
-import javax.annotation.Nullable;
-
 /**
  * Simple read counting pipeline, intended as an example for reading data from 
  * APIs OR BAM files and invoking GATK tools.
+ *
+ * Specify either ReadGroupSet or BAMFilePath.
+ *
+ * Example command line (you have to fill in the env. variables; BAMFilePath is of the "gs://foo/bar" format):
+ * java -cp target/google-genomics*jar com.google.cloud.genomics.dataflow.pipelines.CountReads \
+ *   --project=$PROJECT_ID \
+ *   --stagingLocation=$STAGING \
+ *   --genomicsSecretsFile=$CLIENT_SECRETS \
+ *   --references=$DESIRED_CONTIGS \
+ *   --BAMFilePath=$BAM_FILE_PATH \
+ *   --output=$OUTPUT
+ *
+ * See src/main/scripts/count_reads.sh for more detail.
  */
 public class CountReads {
   private static final Logger LOG = Logger.getLogger(CountReads.class.getName());
   private static CountReadsOptions options;
   private static Pipeline p;
   private static GenomicsFactory.OfflineAuth auth;
+
   public static interface CountReadsOptions extends GenomicsDatasetOptions, GCSOptions {
     @Description("The ID of the Google Genomics ReadGroupSet this pipeline is working with. "
         + "Default (empty) indicates all ReadGroupSets.")
@@ -73,53 +86,51 @@ public class CountReads {
 
     void setReadGroupSetId(String readGroupSetId);
 
-    @Description("The path to the BAM file to get reads data from.")
+    @Description("The Google Storage path to the BAM file to get reads data from, if not using ReadGroupSet.")
     @Default.String("")
     String getBAMFilePath();
 
     void setBAMFilePath(String filePath);
     
-    @Description("Whether to shard BAM reading")
+    @Description("Whether to shard BAM file reading.")
     @Default.Boolean(true)
     boolean getShardBAMReading();
 
     void setShardBAMReading(boolean newValue);
-    
-    class ContigsFactory implements DefaultValueFactory<Iterable<Contig>> {
-      @Override
-      public Iterable<Contig> create(PipelineOptions options) {
-        return Iterables.transform(Splitter.on(",").split(options.as(CountReadsOptions.class).getReferences()),
-            new Function<String, Contig>() {
-              @Override
-              public Contig apply(String contigString) {
-                ArrayList<String> contigInfo = newArrayList(Splitter.on(":").split(contigString));
-                return new Contig(contigInfo.get(0), 
-                    contigInfo.size() > 1 ? 
-                        Long.valueOf(contigInfo.get(1)) : 0, 
-                    contigInfo.size() > 2 ?
-                        Long.valueOf(contigInfo.get(2)) : -1);
-              }
-            });
-      }
-    }
-    
-    @Default.InstanceFactory(ContigsFactory.class)
-    @JsonIgnore
-    Iterable<Contig> getContigs();
-    
-    void setContigs(Iterable<Contig> contigs);
+
   }
-  
+
   public static void main(String[] args) throws GeneralSecurityException, IOException {
     // Register the options so that they show up via --help
     PipelineOptionsFactory.register(CountReadsOptions.class);
     options = PipelineOptionsFactory.fromArgs(args).withValidation().as(CountReadsOptions.class);
     // Option validation is not yet automatic, we make an explicit call here.
     GenomicsDatasetOptions.Methods.validateOptions(options);
-
-    auth = GCSOptions.Methods.createGCSAuth(options);
+    auth = GenomicsOptions.Methods.getGenomicsAuth(options);
     p = Pipeline.create(options);
     DataflowWorkarounds.registerGenomicsCoders(p);
+
+    // ensure data is accessible
+    String BAMFilePath = options.getBAMFilePath();
+    if (!Strings.isNullOrEmpty(BAMFilePath)) {
+      if (GCSURLExists(BAMFilePath)) {
+        System.out.println(BAMFilePath + " is present, good.");
+      } else {
+        System.out.println("Error: " + BAMFilePath + " not found.");
+        return;
+      }
+      if (options.getShardBAMReading()) {
+        // the BAM code expects an index at BAMFilePath+".bai"
+        // and sharded reading will fail if the index isn't there.
+        String BAMIndexPath = BAMFilePath + ".bai";
+        if (GCSURLExists(BAMIndexPath)) {
+          System.out.println(BAMIndexPath + " is present, good.");
+        } else {
+          System.out.println("Error: " + BAMIndexPath + " not found.");
+          return;
+        }
+      }
+    }
 
     PCollection<Read> reads = getReads();
     PCollection<Long> readCount = reads.apply(Count.<Read>globally());
@@ -130,7 +141,23 @@ public class CountReads {
       }
     }).named("toString"));
     readCountText.apply(TextIO.Write.to(options.getOutput()).named("WriteOutput"));
+
     p.run();
+  }
+
+  private static boolean GCSURLExists(String url) {
+    // ensure data is accessible
+    try {
+      // if we can read the size, then surely we can read the file
+      GCSFilename fn = new GCSFilename(url);
+      Storage.Objects storageClient = GCSOptions.Methods.createStorageClient(options, auth);
+      Storage.Objects.Get getter = storageClient.get(fn.bucket, fn.filename);
+      StorageObject object = getter.execute();
+      BigInteger size = object.getSize();
+      return true;
+    } catch (Exception x) {
+      return false;
+    }
   }
 
   private static PCollection<Read> getReads() throws IOException {
@@ -158,8 +185,9 @@ public class CountReads {
   private static List<SearchReadsRequest> getReadRequests(CountReadsOptions options) {
     
     final String readGroupSetId = options.getReadGroupSetId();
+    final Iterable<Contig> contigs = parseContigs(options.getReferences());
     return Lists.newArrayList(Iterables.transform(
-        Iterables.concat(Iterables.transform(options.getContigs(),
+        Iterables.concat(Iterables.transform(contigs,
           new Function<Contig, Iterable<Contig>>() {
             @Override
             public Iterable<Contig> apply(Contig contig) {
@@ -177,14 +205,16 @@ public class CountReads {
   private static PCollection<Read> getReadsFromBAMFile() throws IOException {
     LOG.info("getReadsFromBAMFile");
 
-    final Iterable<Contig> contigs = options.getContigs();
+    final Iterable<Contig> contigs = parseContigs(options.getReferences());
         
     if (options.getShardBAMReading()) {
+      LOG.info("Sharded reading of "+options.getBAMFilePath());
       return ReadBAMTransform.getReadsFromBAMFilesSharded(p, 
           auth,
           contigs, 
           Collections.singletonList(options.getBAMFilePath()));
     } else {  // For testing and comparing sharded vs. not sharded only
+      LOG.info("Unsharded reading of "+options.getBAMFilePath());
       return p.apply(
           Create.of(
               Reader.readSequentiallyForTesting(
@@ -192,5 +222,20 @@ public class CountReads {
                   options.getBAMFilePath(),
                   contigs.iterator().next())));
     }
+  }
+
+  private static Iterable<Contig> parseContigs(String c) {
+    return Iterables.transform(Splitter.on(",").split(c),
+        new Function<String, Contig>() {
+          @Override
+          public Contig apply(String contigString) {
+            ArrayList<String> contigInfo = newArrayList(Splitter.on(":").split(contigString));
+            return new Contig(contigInfo.get(0),
+                contigInfo.size() > 1 ?
+                    Long.valueOf(contigInfo.get(1)) : 0,
+                contigInfo.size() > 2 ?
+                    Long.valueOf(contigInfo.get(2)) : -1);
+          }
+        });
   }
 }

--- a/src/main/java/com/google/cloud/genomics/dataflow/utils/GCSFilename.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/utils/GCSFilename.java
@@ -7,16 +7,24 @@ import java.io.IOException;
  * plus helper code to translate between the (bucket,filename) and "gs://bucket/filename" formats.
  */
 public class GCSFilename {
-  public static final String PREFIX="gs://";
+  public static final String PREFIX = "gs://";
   public final String bucket;
   public final String filename;
-  // fileName can include "/", bucket cannot.
+
+  /**
+   * Hold the (bucket,filename) pair.
+   * filename can include "/", bucket cannot.
+   */
   public GCSFilename(String bucket, String filename) {
     this.bucket = bucket;
     this.filename = filename;
   }
-  // gcsPathUrl is of the form gs://BUCKET/FILENAME
-  // filename can include "/", bucket cannot.
+
+  /**
+   * Parse a GCD URL and hold the result.
+   * gcsPathUrl is of the form gs://BUCKET/FILENAME. filename can include "/", bucket cannot.
+   * @throws IOException
+   */
   public GCSFilename(String gcsPathUrl) throws IOException {
     if (!gcsPathUrl.startsWith(PREFIX)) {
       throw new IOException("Invalid GCS URL (does not start with " + PREFIX + "): " + gcsPathUrl);
@@ -29,6 +37,10 @@ public class GCSFilename {
     this.bucket = suffix.substring(0, slashPos);
     this.filename = suffix.substring(slashPos + 1);
   }
+
+  /**
+   * gs://bucket/filename
+   */
   public String getGCSPath() {
     return PREFIX + bucket + "/" + filename;
   }

--- a/src/main/java/com/google/cloud/genomics/dataflow/utils/GCSFilename.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/utils/GCSFilename.java
@@ -1,0 +1,35 @@
+package com.google.cloud.genomics.dataflow.utils;
+
+import java.io.IOException;
+
+/**
+ * A holder for the (bucket, filename) pairs we get with Google Cloud Storage,
+ * plus helper code to translate between the (bucket,filename) and "gs://bucket/filename" formats.
+ */
+public class GCSFilename {
+  public static final String PREFIX="gs://";
+  public final String bucket;
+  public final String filename;
+  // fileName can include "/", bucket cannot.
+  public GCSFilename(String bucket, String filename) {
+    this.bucket = bucket;
+    this.filename = filename;
+  }
+  // gcsPathUrl is of the form gs://BUCKET/FILENAME
+  // filename can include "/", bucket cannot.
+  public GCSFilename(String gcsPathUrl) throws IOException {
+    if (!gcsPathUrl.startsWith(PREFIX)) {
+      throw new IOException("Invalid GCS URL (does not start with " + PREFIX + "): " + gcsPathUrl);
+    }
+    String suffix = gcsPathUrl.substring(PREFIX.length());
+    int slashPos = suffix.indexOf("/");
+    if (slashPos < 0) {
+      throw new IOException("Invalid GCS URL (does not contain a '/'): " + gcsPathUrl);
+    }
+    this.bucket = suffix.substring(0, slashPos);
+    this.filename = suffix.substring(slashPos + 1);
+  }
+  public String getGCSPath() {
+    return PREFIX + bucket + "/" + filename;
+  }
+}

--- a/src/main/java/com/google/cloud/genomics/dataflow/utils/GCSOptions.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/utils/GCSOptions.java
@@ -29,7 +29,7 @@ import com.google.cloud.dataflow.sdk.transforms.DoFn;
 import com.google.cloud.genomics.utils.GenomicsFactory;
 import com.google.common.collect.ImmutableList;
 
-import org.codehaus.jackson.annotate.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import java.io.IOException;
 import java.util.List;

--- a/src/test/java/com/google/cloud/genomics/dataflow/utils/GCSFilenameTest.java
+++ b/src/test/java/com/google/cloud/genomics/dataflow/utils/GCSFilenameTest.java
@@ -1,0 +1,44 @@
+package com.google.cloud.genomics.dataflow.utils;
+
+import static org.junit.Assert.assertEquals;
+
+import junit.framework.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class GCSFilenameTest  {
+
+  @Test
+  public void testGetGCSPathRoundtrip() throws Exception {
+    String[] urls = {
+        "gs://bucket/path/file.xml",
+        "gs://bucket/file"
+    };
+    for (String url : urls) {
+      String roundTrip = new GCSFilename(url).getGCSPath();
+      assertEquals(url, roundTrip);
+    }
+  }
+
+  @Test
+  public void testGetGCSPathMalformed() throws Exception {
+    String[] urls = {
+        "C:\\AUTOEXEC.BAT",
+        "file://foo/bar",
+        "foo/bar",
+        "http://example.com",
+        "gs://bucket"
+    };
+    for (String url : urls) {
+      try {
+        String roundTrip = new GCSFilename(url).getGCSPath();
+        Assert.fail("Should have gotten an error for invalid GCS URL '" + url + "'");
+      } catch (Exception x) {
+        // Good, we wanted an exception
+      }
+
+    }
+  }
+}


### PR DESCRIPTION
- fixed GCSOptions.Methods.createGCSAuth so it can work on the cloud again
- fixed all imports to use the correct Jackson library
- mentioned count_reads.sh so people can use code as documentation
- expanded CountReads top documentation a bit to save everyone time
- removed unnecessary contigs options. The documented way of specifying contigs remains to use the "references" option.