### PR TITLE
GenomicsDatasetOptions:validateOptions calls into GCSFilename

### DIFF
--- a/src/main/java/com/google/cloud/genomics/dataflow/utils/GCSFilename.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/utils/GCSFilename.java
@@ -1,6 +1,6 @@
 package com.google.cloud.genomics.dataflow.utils;
 
-import com.google.api.client.repackaged.com.google.common.base.Preconditions;
+import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 
 import java.io.IOException;

--- a/src/main/java/com/google/cloud/genomics/dataflow/utils/GenomicsDatasetOptions.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/utils/GenomicsDatasetOptions.java
@@ -69,7 +69,12 @@ public interface GenomicsDatasetOptions extends GenomicsOptions {
 
     public static void validateOptions(GenomicsDatasetOptions options) {
       Preconditions.checkArgument(0 < options.getBinSize(), "binSize must be greater than zero");
-      Preconditions.checkArgument(options.getOutput().startsWith("gs://"), "output must be a valid Google Cloud Storage path.");
+      try {
+        // check we can parse it
+        GCSFilename valid = new GCSFilename(options.getOutput());
+      } catch (Exception x) {
+        Preconditions.checkState(false, "output must be a valid Google Cloud Storage URL (starting with gs://)");
+      }
       GenomicsOptions.Methods.validateOptions(options);
     }
   }

--- a/src/test/java/com/google/cloud/genomics/dataflow/utils/GCSFilenameTest.java
+++ b/src/test/java/com/google/cloud/genomics/dataflow/utils/GCSFilenameTest.java
@@ -29,7 +29,9 @@ public class GCSFilenameTest  {
         "file://foo/bar",
         "foo/bar",
         "http://example.com",
-        "gs://bucket"
+        "gs://bucket",
+        "gs://bucket/",
+        "gs:///filename"
     };
     for (String url : urls) {
       try {
@@ -40,5 +42,13 @@ public class GCSFilenameTest  {
       }
 
     }
+  }
+
+  @Test
+  public void testGetGCSPathDefault() throws Exception {
+    String url = "gs:///path/file.xml";
+    String expected = "gs://bucket/path/file.xml";
+    String roundTrip = GCSFilename.URLWithDefaultBucket(url,"bucket").getGCSPath();
+    assertEquals(expected, roundTrip);
   }
 }


### PR DESCRIPTION
Made GCSFilename a bit more stringent and changed GenomicsDatasetOptions:validateOptions to use it. Also removed some unnecessary code.