### PR TITLE
test CountReads running on cloud.

### DIFF
--- a/src/test/java/com/google/cloud/genomics/dataflow/pipelines/CountReadsITCase.java
+++ b/src/test/java/com/google/cloud/genomics/dataflow/pipelines/CountReadsITCase.java
@@ -12,12 +12,17 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.Writer;
 import java.nio.channels.Channels;
+import java.nio.channels.WritableByteChannel;
 
 /**
- * This test expects you to have a Google Cloud API key in the GOOGLE_API_KEY environment variable,
- * and a GCS folder path in TEST_OUTPUT_GCS_FOLDER to store temporary test outputs.
- * It should be of the form "gs://bucket/folder/"
+ * This test expects you to have:
+ * -a Google Cloud API key in the GOOGLE_API_KEY environment variable,
+ * -a GCS folder path in TEST_OUTPUT_GCS_FOLDER to store temporary test outputs,
+ * -a GCS folder path in TEST_STAGING_GCS_FOLDER to store temporary files,
+ * GCS folder paths should be of the form "gs://bucket/folder/"
  *
  * This test will read and write to GCS.
  */
@@ -26,6 +31,7 @@ public class CountReadsITCase {
 
   final String API_KEY = System.getenv("GOOGLE_API_KEY");
   final String TEST_OUTPUT_GCS_FOLDER = System.getenv("TEST_OUTPUT_GCS_FOLDER");
+  final String TEST_STAGING_GCS_FOLDER = System.getenv("TEST_STAGING_GCS_FOLDER");
   // this file shouldn't move.
   final String TEST_BAM_FNAME = "gs://genomics-public-data/ftp-trace.ncbi.nih.gov/1000genomes/ftp/pilot_data/data/NA06985/alignment/NA06985.454.MOSAIK.SRP000033.2009_11.bam";
 
@@ -35,6 +41,9 @@ public class CountReadsITCase {
     Assert.assertNotNull("You must set the TEST_OUTPUT_GCS_FOLDER environment variable for this test.", TEST_OUTPUT_GCS_FOLDER);
     Assert.assertTrue("TEST_OUTPUT_GCS_FOLDER must end with '/'", TEST_OUTPUT_GCS_FOLDER.endsWith("/"));
     Assert.assertTrue("TEST_OUTPUT_GCS_FOLDER must start with 'gs://'", TEST_OUTPUT_GCS_FOLDER.startsWith("gs://"));
+    Assert.assertNotNull("You must set the TEST_STAGING_GCS_FOLDER environment variable for this test.", TEST_STAGING_GCS_FOLDER);
+    Assert.assertTrue("TEST_STAGING_GCS_FOLDER must start with 'gs://'", TEST_STAGING_GCS_FOLDER.startsWith("gs://"));
+    // we don't care how TEST_STAGING_GCS_FOLDER ends, so no check for it.
   }
 
   /**
@@ -44,22 +53,63 @@ public class CountReadsITCase {
   public void testLocal() throws Exception {
     final String OUTPUT = TEST_OUTPUT_GCS_FOLDER + "CountReadsITCase-testLocal-output.txt";
     String[] ARGS = {
-        "--apiKey="+API_KEY,
+        "--apiKey=" + API_KEY,
         "--project=genomics-pipelines",
         "--output=" + OUTPUT,
         "--references=1:550000:560000",
-        "--BAMFilePath="+TEST_BAM_FNAME
+        "--BAMFilePath=" + TEST_BAM_FNAME
     };
     final long EXPECTED = 685;
     GenomicsOptions popts = PipelineOptionsFactory.create().as(GenomicsOptions.class);
     popts.setApiKey(API_KEY);
     GcsUtil gcsUtil = new GcsUtil.GcsUtilFactory().create(popts);
+    touchOutput(gcsUtil, OUTPUT);
 
     CountReads.main(ARGS);
 
     BufferedReader reader = new BufferedReader(Channels.newReader(gcsUtil.open(GcsPath.fromUri(OUTPUT)), "UTF-8"));
     long got = Long.parseLong(reader.readLine());
+
     Assert.assertEquals(EXPECTED, got);
   }
 
+  /**
+   * CountReads running on Dataflow.
+   */
+  @Test
+  public void testCloud() throws Exception {
+    final String OUTPUT = TEST_OUTPUT_GCS_FOLDER + "CountReadsITCase-testCloud-output.txt";
+    String[] ARGS = {
+        "--apiKey="+API_KEY,
+        "--project=genomics-pipelines",
+        "--output=" + OUTPUT,
+        "--numWorkers=2",
+        "--runner=BlockingDataflowPipelineRunner",
+        "--stagingLocation=" + TEST_STAGING_GCS_FOLDER,
+        "--references=1:550000:560000",
+        "--BAMFilePath=" + TEST_BAM_FNAME
+    };
+    final long EXPECTED = 685;
+    GenomicsOptions popts = PipelineOptionsFactory.create().as(GenomicsOptions.class);
+    popts.setApiKey(API_KEY);
+    GcsUtil gcsUtil = new GcsUtil.GcsUtilFactory().create(popts);
+    touchOutput(gcsUtil, OUTPUT);
+
+    CountReads.main(ARGS);
+
+    BufferedReader reader = new BufferedReader(Channels.newReader(gcsUtil.open(GcsPath.fromUri(OUTPUT)), "UTF-8"));
+    long got = Long.parseLong(reader.readLine());
+
+    Assert.assertEquals(EXPECTED, got);
+  }
+
+  /**
+   * make sure we can get to the output, and at the same time avoid a false negative if
+   * the program does nothing and we find the output from an earlier run.
+   */
+  private void touchOutput(GcsUtil gcsUtil, String outputGcsPath) throws IOException {
+    try (Writer writer = Channels.newWriter(gcsUtil.create(GcsPath.fromUri(outputGcsPath), "text/plain"), "UTF-8")) {
+      writer.write("output will go here");
+    }
+  }
 }

--- a/src/test/java/com/google/cloud/genomics/dataflow/pipelines/CountReadsITCase.java
+++ b/src/test/java/com/google/cloud/genomics/dataflow/pipelines/CountReadsITCase.java
@@ -20,6 +20,7 @@ import java.nio.channels.WritableByteChannel;
 /**
  * This test expects you to have:
  * -a Google Cloud API key in the GOOGLE_API_KEY environment variable,
+ * -your Google Cloud project name in TEST_PROJECT,
  * -a GCS folder path in TEST_OUTPUT_GCS_FOLDER to store temporary test outputs,
  * -a GCS folder path in TEST_STAGING_GCS_FOLDER to store temporary files,
  * GCS folder paths should be of the form "gs://bucket/folder/"
@@ -30,6 +31,7 @@ import java.nio.channels.WritableByteChannel;
 public class CountReadsITCase {
 
   final String API_KEY = System.getenv("GOOGLE_API_KEY");
+  final String TEST_PROJECT = System.getenv("TEST_PROJECT");
   final String TEST_OUTPUT_GCS_FOLDER = System.getenv("TEST_OUTPUT_GCS_FOLDER");
   final String TEST_STAGING_GCS_FOLDER = System.getenv("TEST_STAGING_GCS_FOLDER");
   // this file shouldn't move.
@@ -38,6 +40,7 @@ public class CountReadsITCase {
   @Before
   public void voidEnsureEnvVar() {
     Assert.assertNotNull("You must set the GOOGLE_API_KEY environment variable for this test.", API_KEY);
+    Assert.assertNotNull("You must set the TEST_PROJECT environment variable for this test.", TEST_PROJECT);
     Assert.assertNotNull("You must set the TEST_OUTPUT_GCS_FOLDER environment variable for this test.", TEST_OUTPUT_GCS_FOLDER);
     Assert.assertTrue("TEST_OUTPUT_GCS_FOLDER must end with '/'", TEST_OUTPUT_GCS_FOLDER.endsWith("/"));
     Assert.assertTrue("TEST_OUTPUT_GCS_FOLDER must start with 'gs://'", TEST_OUTPUT_GCS_FOLDER.startsWith("gs://"));
@@ -54,7 +57,7 @@ public class CountReadsITCase {
     final String OUTPUT = TEST_OUTPUT_GCS_FOLDER + "CountReadsITCase-testLocal-output.txt";
     String[] ARGS = {
         "--apiKey=" + API_KEY,
-        "--project=genomics-pipelines",
+        "--project=" + TEST_PROJECT,
         "--output=" + OUTPUT,
         "--references=1:550000:560000",
         "--BAMFilePath=" + TEST_BAM_FNAME
@@ -80,8 +83,8 @@ public class CountReadsITCase {
   public void testCloud() throws Exception {
     final String OUTPUT = TEST_OUTPUT_GCS_FOLDER + "CountReadsITCase-testCloud-output.txt";
     String[] ARGS = {
-        "--apiKey="+API_KEY,
-        "--project=genomics-pipelines",
+        "--apiKey=" + API_KEY,
+        "--project=" + TEST_PROJECT,
         "--output=" + OUTPUT,
         "--numWorkers=2",
         "--runner=BlockingDataflowPipelineRunner",


### PR DESCRIPTION
Added a method to test CountReads' second mode of operation (and added the corresponding env variable to Travis).

You can run this test from the IDE (it passes there); the command line still doesn't work for it.

Sorry about the broken diff, that's outside of my control.