### PR TITLE
testCloudWithAPI

### DIFF
--- a/src/test/java/com/google/cloud/genomics/dataflow/pipelines/CountReadsITCase.java
+++ b/src/test/java/com/google/cloud/genomics/dataflow/pipelines/CountReadsITCase.java
@@ -15,7 +15,6 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.Writer;
 import java.nio.channels.Channels;
-import java.nio.channels.WritableByteChannel;
 
 /**
  * This test expects you to have:
@@ -25,7 +24,7 @@ import java.nio.channels.WritableByteChannel;
  * -a GCS folder path in TEST_STAGING_GCS_FOLDER to store temporary files,
  * GCS folder paths should be of the form "gs://bucket/folder/"
  *
- * This test will read and write to GCS.
+ * This test will read and write to GCS, and call the Genomics API.
  */
 @RunWith(JUnit4.class)
 public class CountReadsITCase {
@@ -34,8 +33,14 @@ public class CountReadsITCase {
   final String TEST_PROJECT = System.getenv("TEST_PROJECT");
   final String TEST_OUTPUT_GCS_FOLDER = System.getenv("TEST_OUTPUT_GCS_FOLDER");
   final String TEST_STAGING_GCS_FOLDER = System.getenv("TEST_STAGING_GCS_FOLDER");
-  // this file shouldn't move.
+  // This file shouldn't move.
   final String TEST_BAM_FNAME = "gs://genomics-public-data/ftp-trace.ncbi.nih.gov/1000genomes/ftp/pilot_data/data/NA06985/alignment/NA06985.454.MOSAIK.SRP000033.2009_11.bam";
+  // This is the Readgroupset ID of the same file, in ReadStore. It also shouldn't move.
+  final String TEST_READGROUPSET = "CMvnhpKTFhDvp9zAvYj66AY";
+  // The region where we're counting reads.
+  final String TEST_CONTIG = "1:550000:560000";
+  // How many reads are in that region.
+  final long TEST_EXPECTED = 685;
 
   @Before
   public void voidEnsureEnvVar() {
@@ -59,10 +64,9 @@ public class CountReadsITCase {
         "--apiKey=" + API_KEY,
         "--project=" + TEST_PROJECT,
         "--output=" + OUTPUT,
-        "--references=1:550000:560000",
+        "--references=" + TEST_CONTIG,
         "--BAMFilePath=" + TEST_BAM_FNAME
     };
-    final long EXPECTED = 685;
     GenomicsOptions popts = PipelineOptionsFactory.create().as(GenomicsOptions.class);
     popts.setApiKey(API_KEY);
     GcsUtil gcsUtil = new GcsUtil.GcsUtilFactory().create(popts);
@@ -73,7 +77,7 @@ public class CountReadsITCase {
     BufferedReader reader = new BufferedReader(Channels.newReader(gcsUtil.open(GcsPath.fromUri(OUTPUT)), "UTF-8"));
     long got = Long.parseLong(reader.readLine());
 
-    Assert.assertEquals(EXPECTED, got);
+    Assert.assertEquals(TEST_EXPECTED, got);
   }
 
   /**
@@ -89,10 +93,9 @@ public class CountReadsITCase {
         "--numWorkers=2",
         "--runner=BlockingDataflowPipelineRunner",
         "--stagingLocation=" + TEST_STAGING_GCS_FOLDER,
-        "--references=1:550000:560000",
+        "--references=" + TEST_CONTIG,
         "--BAMFilePath=" + TEST_BAM_FNAME
     };
-    final long EXPECTED = 685;
     GenomicsOptions popts = PipelineOptionsFactory.create().as(GenomicsOptions.class);
     popts.setApiKey(API_KEY);
     GcsUtil gcsUtil = new GcsUtil.GcsUtilFactory().create(popts);
@@ -103,11 +106,40 @@ public class CountReadsITCase {
     BufferedReader reader = new BufferedReader(Channels.newReader(gcsUtil.open(GcsPath.fromUri(OUTPUT)), "UTF-8"));
     long got = Long.parseLong(reader.readLine());
 
-    Assert.assertEquals(EXPECTED, got);
+    Assert.assertEquals(TEST_EXPECTED, got);
   }
 
   /**
-   * make sure we can get to the output, and at the same time avoid a false negative if
+   * CountReads running on Dataflow with API input.
+   */
+  @Test
+  public void testCloudWithAPI() throws Exception {
+    final String OUTPUT = TEST_OUTPUT_GCS_FOLDER + "CountReadsITCase-testCloudWithAPI-output.txt";
+    String[] ARGS = {
+        "--apiKey=" + API_KEY,
+        "--project=" + TEST_PROJECT,
+        "--output=" + OUTPUT,
+        "--numWorkers=2",
+        "--runner=BlockingDataflowPipelineRunner",
+        "--stagingLocation=" + TEST_STAGING_GCS_FOLDER,
+        "--references=" + TEST_CONTIG,
+        "--readGroupSetId=" + TEST_READGROUPSET
+    };
+    GenomicsOptions popts = PipelineOptionsFactory.create().as(GenomicsOptions.class);
+    popts.setApiKey(API_KEY);
+    GcsUtil gcsUtil = new GcsUtil.GcsUtilFactory().create(popts);
+    touchOutput(gcsUtil, OUTPUT);
+
+    CountReads.main(ARGS);
+
+    BufferedReader reader = new BufferedReader(Channels.newReader(gcsUtil.open(GcsPath.fromUri(OUTPUT)), "UTF-8"));
+    long got = Long.parseLong(reader.readLine());
+
+    Assert.assertEquals(TEST_EXPECTED, got);
+  }
+
+  /**
+   * Make sure we can get to the output, and at the same time avoid a false negative if
    * the program does nothing and we find the output from an earlier run.
    */
   private void touchOutput(GcsUtil gcsUtil, String outputGcsPath) throws IOException {
@@ -115,4 +147,6 @@ public class CountReadsITCase {
       writer.write("output will go here");
     }
   }
+
+
 }


### PR DESCRIPTION
added a test that uses the Genomics API to get to the reads (instead of Google Cloud Storage). Put a copy of the same input file onto a publicly accessible ReadStore database.