### PR TITLE
Refactor auth

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -288,6 +288,9 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
         <version>2.18.1</version>
+        <configuration>
+          <useSystemClassLoader>false</useSystemClassLoader>
+        </configuration>
         <executions>
           <execution>
             <goals>

--- a/src/main/java/com/google/cloud/genomics/dataflow/pipelines/CountReads.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/pipelines/CountReads.java
@@ -20,8 +20,6 @@ import com.google.api.services.genomics.model.SearchReadsRequest;
 import com.google.api.services.storage.Storage;
 import com.google.api.services.storage.model.StorageObject;
 import com.google.cloud.dataflow.sdk.Pipeline;
-import com.google.cloud.dataflow.sdk.coders.StandardCoder;
-import com.google.cloud.dataflow.sdk.coders.StringUtf8Coder;
 import com.google.cloud.dataflow.sdk.io.TextIO;
 import com.google.cloud.dataflow.sdk.options.Default;
 import com.google.cloud.dataflow.sdk.options.Description;

--- a/src/main/java/com/google/cloud/genomics/dataflow/utils/GCSOptions.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/utils/GCSOptions.java
@@ -32,6 +32,7 @@ import com.google.common.collect.ImmutableList;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import java.io.IOException;
+import java.security.GeneralSecurityException;
 import java.util.List;
 import java.util.logging.Logger;
 
@@ -121,12 +122,16 @@ public interface GCSOptions extends GenomicsOptions {
     }
     
     public static Storage.Objects createStorageClient(
-        DoFn<?, ?>.Context context, GenomicsFactory.OfflineAuth auth) throws IOException {
+        DoFn<?, ?>.Context context) throws GeneralSecurityException, IOException {
       final GCSOptions gcsOptions =
           context.getPipelineOptions().as(GCSOptions.class);
-      return createStorageClient(gcsOptions, auth);
+      return createStorageClient(gcsOptions);
     }
-    
+
+    public static Storage.Objects createStorageClient(GCSOptions gcsOptions) throws GeneralSecurityException, IOException {
+      return createStorageClient(gcsOptions, GenomicsOptions.Methods.getGenomicsAuth(gcsOptions));
+    }
+
     public static Storage.Objects createStorageClient(GCSOptions gcsOptions,
         GenomicsFactory.OfflineAuth auth) throws IOException {
       LOG.info("Creating storgae client for " + auth.applicationName);

--- a/src/test/java/com/google/cloud/genomics/dataflow/pipelines/CountReadsITCase.java
+++ b/src/test/java/com/google/cloud/genomics/dataflow/pipelines/CountReadsITCase.java
@@ -83,6 +83,7 @@ public class CountReadsITCase {
   /**
    * CountReads running on Dataflow.
    */
+  /*
   @Test
   public void testCloud() throws Exception {
     final String OUTPUT = TEST_OUTPUT_GCS_FOLDER + "CountReadsITCase-testCloud-output.txt";
@@ -107,11 +108,12 @@ public class CountReadsITCase {
     long got = Long.parseLong(reader.readLine());
 
     Assert.assertEquals(TEST_EXPECTED, got);
-  }
+  }*/
 
   /**
    * CountReads running on Dataflow with API input.
    */
+  /*
   @Test
   public void testCloudWithAPI() throws Exception {
     final String OUTPUT = TEST_OUTPUT_GCS_FOLDER + "CountReadsITCase-testCloudWithAPI-output.txt";
@@ -136,7 +138,7 @@ public class CountReadsITCase {
     long got = Long.parseLong(reader.readLine());
 
     Assert.assertEquals(TEST_EXPECTED, got);
-  }
+  }*/
 
   /**
    * Make sure we can get to the output, and at the same time avoid a false negative if

--- a/src/test/java/com/google/cloud/genomics/dataflow/pipelines/CountReadsITCase.java
+++ b/src/test/java/com/google/cloud/genomics/dataflow/pipelines/CountReadsITCase.java
@@ -83,7 +83,6 @@ public class CountReadsITCase {
   /**
    * CountReads running on Dataflow.
    */
-  /*
   @Test
   public void testCloud() throws Exception {
     final String OUTPUT = TEST_OUTPUT_GCS_FOLDER + "CountReadsITCase-testCloud-output.txt";
@@ -108,12 +107,11 @@ public class CountReadsITCase {
     long got = Long.parseLong(reader.readLine());
 
     Assert.assertEquals(TEST_EXPECTED, got);
-  }*/
+  }
 
   /**
    * CountReads running on Dataflow with API input.
    */
-  /*
   @Test
   public void testCloudWithAPI() throws Exception {
     final String OUTPUT = TEST_OUTPUT_GCS_FOLDER + "CountReadsITCase-testCloudWithAPI-output.txt";
@@ -138,7 +136,7 @@ public class CountReadsITCase {
     long got = Long.parseLong(reader.readLine());
 
     Assert.assertEquals(TEST_EXPECTED, got);
-  }*/
+  }
 
   /**
    * Make sure we can get to the output, and at the same time avoid a false negative if


### PR DESCRIPTION
This refactor moves the offline authentication properly into this library code. Before this change clients needed to create offline authentication classes. The authentication can/should be derived from the Options that are associated with the pipeline. This refactor creates the OfflineAuth where it's needed in GCSOptions.java. ReadBAMTransform.java now no longer has any references to OfflineAuth.

There are two main consequences for the client:
1) The ReadBAMTransform API has changed to no longer accept OfflineAuth, so this is not a no-op for client code. (Note that I didn't remove the existing functions in GCSOptions so it's still possible to pass in OfflineAuth to createStorageClient).
2) Because we're creating the OfflineAuth using GenomicsOptions.Methods.getGenomicsAuth, ReadBAMTransform now throws GeneralSecurityException.

I've run mvn clean install: everything builds and all tests pass.