### PR TITLE
Added the CalculateCoverage pipeline/tests.

### DIFF
--- a/src/main/java/com/google/cloud/genomics/dataflow/pipelines/CalculateCoverage.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/pipelines/CalculateCoverage.java
@@ -1,0 +1,512 @@
+/*
+ * Copyright (C) 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.genomics.dataflow.pipelines;
+
+import com.google.api.services.genomics.Genomics;
+import com.google.api.services.genomics.model.Annotation;
+import com.google.api.services.genomics.model.AnnotationSet;
+import com.google.api.services.genomics.model.BatchCreateAnnotationsRequest;
+import com.google.api.services.genomics.model.CigarUnit;
+import com.google.api.services.genomics.model.Position;
+import com.google.api.services.genomics.model.RangePosition;
+import com.google.api.services.genomics.model.Read;
+import com.google.api.services.genomics.model.ReadGroupSet;
+import com.google.api.services.genomics.model.SearchReadGroupSetsRequest;
+import com.google.api.services.genomics.model.SearchReadsRequest;
+import com.google.cloud.dataflow.sdk.Pipeline;
+import com.google.cloud.dataflow.sdk.options.Default;
+import com.google.cloud.dataflow.sdk.options.Description;
+import com.google.cloud.dataflow.sdk.options.PipelineOptionsFactory;
+import com.google.cloud.dataflow.sdk.transforms.ApproximateQuantiles;
+import com.google.cloud.dataflow.sdk.transforms.Combine;
+import com.google.cloud.dataflow.sdk.transforms.Create;
+import com.google.cloud.dataflow.sdk.transforms.DoFn;
+import com.google.cloud.dataflow.sdk.transforms.GroupByKey;
+import com.google.cloud.dataflow.sdk.transforms.PTransform;
+import com.google.cloud.dataflow.sdk.transforms.ParDo;
+import com.google.cloud.dataflow.sdk.transforms.SerializableFunction;
+import com.google.cloud.dataflow.sdk.values.KV;
+import com.google.cloud.dataflow.sdk.values.PCollection;
+import com.google.cloud.genomics.dataflow.coders.GenericJsonCoder;
+import com.google.cloud.genomics.dataflow.readers.ReadReader;
+import com.google.cloud.genomics.dataflow.utils.DataflowWorkarounds;
+import com.google.cloud.genomics.dataflow.utils.GCSOptions;
+import com.google.cloud.genomics.dataflow.utils.GenomicsDatasetOptions;
+import com.google.cloud.genomics.dataflow.utils.GenomicsOptions;
+import com.google.cloud.genomics.utils.Contig;
+import com.google.cloud.genomics.utils.GenomicsFactory;
+import com.google.cloud.genomics.utils.Paginator;
+import com.google.cloud.genomics.utils.RetryPolicy;
+import com.google.common.base.Function;
+import com.google.common.collect.FluentIterable;
+import com.google.common.collect.Lists;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.HashMap;
+import java.util.List;
+
+/**
+ * Class for calculating read depth coverage for a given data set.
+ *
+ * For each "bucket" in the given input references, this computes the average coverage (rounded to
+ * six decimal places) across the bucket that 10%, 20%, 30%, etc. of the input ReadGroupsSets have
+ * for each mapping quality of the reads (<10:Low(L), 10-29:Medium(M), >=30:High(H)) as well as
+ * these same percentiles of ReadGroupSets for all reads regardless of mapping quality (Mapping
+ * quality All(A)).
+ *
+ * There is also the option to change the number of quantiles accordingly (numQuantiles = 5 would
+ * give you the minimum ReadGroupSet mean coverage for each and across all mapping qualities, the
+ * 25th, 50th, and 75th percentiles, and the maximum of these values).
+ */
+public class CalculateCoverage {
+
+  private static CoverageOptions options;
+  private static Pipeline p;
+  private static GenomicsFactory.OfflineAuth auth;
+
+  /**
+   * Options required to run this pipeline.
+   *
+   * When specifying references, if you specify a nonzero starting point for any given reference,
+   * reads that start before that reference, even if they overlap with the reference, will NOT be
+   * counted.
+   */
+  public static interface CoverageOptions extends GenomicsDatasetOptions, GCSOptions {
+
+    @Description("A comma delimited list of the IDs of the Google Genomics ReadGroupSets this "
+        + "pipeline is working with. Default (empty) indicates all ReadGroupSets in InputDatasetId."
+        + "  This or InputDatasetId must be set.  InputDatasetId overrides ReadGroupSetIds "
+        + "(if InputDatasetId is set, this field will be ignored).  All of the referenceSetIds for"
+        + " all ReadGroupSets in this list must be the same for the purposes of setting the"
+        + " referenceSetId of the output AnnotationSet.")
+    @Default.String("")
+    String getReadGroupSetIds();
+
+    void setReadGroupSetIds(String readGroupSetId);
+
+    @Description("The ID of the Google Genomics Dataset that the pipeline will get its input reads"
+        + " from.  Default (empty) means to use ReadGroupSetIds instead.  This or ReadGroupSetIds"
+        + " must be set.  InputDatasetId overrides ReadGroupSetIds (if this field is set, "
+        + "ReadGroupSetIds will be ignored).  All of the referenceSetIds for all ReadGroupSets in"
+        + " this Dataset must be the same for the purposes of setting the referenceSetId"
+        + " of the output AnnotationSet.")
+    @Default.String("")
+    String getInputDatasetId();
+
+    void setInputDatasetId(String inputDatasetId);
+
+    @Description("The ID of the Google Genomics Dataset that the output AnnotationSet will be "
+        + "posted to.  If one is not specified, the InputDatasetId or the DatasetId field will be "
+        + "used (Defaults to 1000 Genomes).")
+    @Default.String("")
+    String getOutputDatasetId();
+
+    void setOutputDatasetId(String outputDatasetId);
+
+    @Description("The bucket width you would like to calculate coverage for.  Default is 2048.  "
+        + "Buckets are non-overlapping.  If bucket width does not divide into the reference "
+        + "size, then the remainder will be a smaller bucket at the end of the reference.")
+    @Default.Integer(2048)
+    int getBucketWidth();
+
+    void setBucketWidth(int bucketWidth);
+
+    @Description("The number of quantiles you would like to calculate for in the output.  Default"
+        + "is 11 (minimum value for a particular grouping, 10-90 percentiles, and the maximum"
+        + " value).  The InputDataset or list of ReadGroupSetIds specified must have an amount of "
+        + "ReadGroupSetIds greater than or equal to the number of quantiles that you are asking "
+        + "for.")
+    @Default.Integer(11)
+    int getNumQuantiles();
+
+    void setNumQuantiles(int numQuantiles);
+  }
+
+  public static void main(String[] args) throws GeneralSecurityException, IOException {
+    // Register the options so that they show up via --help
+    PipelineOptionsFactory.register(CoverageOptions.class);
+    options = PipelineOptionsFactory.fromArgs(args).withValidation().as(CoverageOptions.class);
+    // Option validation is not yet automatic, we make an explicit call here.
+    GenomicsDatasetOptions.Methods.validateOptions(options);
+    auth = GenomicsOptions.Methods.getGenomicsAuth(options);
+    p = Pipeline.create(options);
+    DataflowWorkarounds.registerGenomicsCoders(p);
+    DataflowWorkarounds.registerCoder(p, PosRgsMq.class, GenericJsonCoder.of(PosRgsMq.class));
+
+    if (options.getInputDatasetId().isEmpty() && options.getReadGroupSetIds().isEmpty()) {
+      throw new IllegalArgumentException("InputDatasetId or ReadGroupSetIds must be specified");
+    }
+
+    List<String> rgsIds = getReadGroupSetIds();
+
+    if (rgsIds.size() < options.getNumQuantiles()) {
+      throw new IllegalArgumentException("Number of ReadGroupSets must be greater than or equal to"
+          + " the number of requested quantiles.");
+    }
+
+    AnnotationSet annotationSet = createAnnotationSet(checkReferenceSetIds(rgsIds));
+
+    PCollection<Read> reads = getReadsFromAPI(rgsIds);
+    PCollection<KV<PosRgsMq, Double>> coverageMeans = reads.apply(new CalculateCoverageMean());
+    PCollection<KV<Position, KV<PosRgsMq.MappingQuality, List<Double>>>> quantiles
+        = coverageMeans.apply(new CalculateQuantiles(options.getNumQuantiles()));
+    PCollection<KV<Position, Iterable<KV<PosRgsMq.MappingQuality, List<Double>>>>> answer =
+        quantiles.apply(GroupByKey.<Position, KV<PosRgsMq.MappingQuality, List<Double>>>create());
+    answer.apply(ParDo.of(new CreateAnnotations(annotationSet.getId(), auth, true)));
+
+    p.run();
+  }
+
+  /**
+   * Composite PTransform that takes in Reads read in from various ReadGroupSetIds using the
+   * Genomics API and calculates the coverage mean at every distinct PosRgsMq object for the data
+   * input (Position, ReadgroupSetId, and Mapping Quality).
+   */
+  public static class CalculateCoverageMean extends PTransform<PCollection<Read>,
+      PCollection<KV<PosRgsMq, Double>>> {
+
+    @Override
+    public PCollection<KV<PosRgsMq, Double>> apply(PCollection<Read> input) {
+      return input.apply(ParDo.of(new CoverageCounts()))
+          .apply(Combine.<PosRgsMq, Long>perKey(new SumCounts()))
+          .apply(ParDo.of(new CoverageMeans()));
+    }
+  }
+
+  static class CoverageCounts extends DoFn<Read, KV<PosRgsMq, Long>> {
+
+    private static final int LOW_MQ = 10;
+    private static final int HIGH_MQ = 30;
+
+    @Override
+    public void processElement(ProcessContext c) {
+      if (c.element().getAlignment() != null) { //is mapped
+        // Calculate length of read
+        long readLength = 0;
+        for (CigarUnit cigar : c.element().getAlignment().getCigar()) {
+          switch (cigar.getOperation()) {
+            case "ALIGNMENT_MATCH":
+            case "SEQUENCE_MATCH":
+            case "SEQUENCE_MISMATCH":
+            case "PAD":
+            case "DELETE":
+            case "SKIP":
+              readLength += cigar.getOperationLength().intValue();
+              break;
+          }
+        }
+        // Get options for getting references/bucket width
+        CoverageOptions pOptions = c.getPipelineOptions().as(CoverageOptions.class);
+        // Calculate readEnd by shifting readStart by readLength
+        long readStart = c.element().getAlignment().getPosition().getPosition();
+        long readEnd = readStart + readLength;
+        // Get starting and ending references
+        long refStart = 0;
+        long refEnd = Long.MAX_VALUE;
+        if (!pOptions.isAllReferences()) {
+          // If we aren't using all references, parse the references to get proper start and end
+          Iterable<Contig> contigs = Contig.parseContigsFromCommandLine(pOptions.getReferences());
+          for (Contig ct : contigs) {
+            if (ct.referenceName
+                .equals(c.element().getAlignment().getPosition().getReferenceName())) {
+              refStart = ct.start;
+              refEnd = ct.end;
+            }
+          }
+        }
+        // Calculate the index of the first bucket this read falls into
+        long bucket = ((readStart - refStart)
+            / pOptions.getBucketWidth()) * pOptions.getBucketWidth() + refStart;
+        long readCurr = readStart;
+        if (readStart < refStart) {
+          // If the read starts before the first bucket, start our calculations at the start of
+          // the reference, since we know the read has to overlap there or else it wouldn't
+          // be in our data set.
+          bucket = refStart;
+          readCurr = refStart;
+        }
+        while (readCurr < readEnd && readCurr < refEnd) {
+          // Loop over read to generate output for each bucket
+          long baseCount = 0;
+          long dist = Math.min(bucket + pOptions.getBucketWidth(), readEnd) - readCurr;
+          readCurr += dist;
+          baseCount += dist;
+          Position p = new Position();
+          p.setPosition(bucket);
+          p.setReferenceName(c.element().getAlignment().getPosition().getReferenceName());
+          Integer mq = c.element().getAlignment().getMappingQuality();
+          if (mq == null) {
+            mq = 0;
+          }
+          PosRgsMq.MappingQuality mqEnum;
+          if (mq < LOW_MQ) {
+            mqEnum = PosRgsMq.MappingQuality.L;
+          } else if (mq >= LOW_MQ && mq < HIGH_MQ) {
+            mqEnum = PosRgsMq.MappingQuality.M;
+          } else {
+            mqEnum = PosRgsMq.MappingQuality.H;
+          }
+          c.output(KV.of(new PosRgsMq(p, c.element().getReadGroupSetId(), mqEnum), baseCount));
+          c.output(KV.of(new PosRgsMq(
+              p, c.element().getReadGroupSetId(), PosRgsMq.MappingQuality.A), baseCount));
+          bucket += pOptions.getBucketWidth();
+        }
+      }
+    }
+  }
+
+  static class SumCounts implements SerializableFunction<Iterable<Long>, Long> {
+
+    @Override
+    public Long apply(Iterable<Long> input) {
+      long ans = 0;
+      for (Long l : input) {
+        ans += l;
+      }
+      return ans;
+    }
+  }
+
+  static class CoverageMeans extends DoFn<KV<PosRgsMq, Long>, KV<PosRgsMq, Double>> {
+
+    @Override
+    public void processElement(ProcessContext c) {
+      KV ans = KV.of(c.element().getKey(),
+          (double) c.element().getValue()
+          / (double) c.getPipelineOptions().as(CoverageOptions.class).getBucketWidth());
+      c.output(ans);
+    }
+  }
+
+  /**
+   * Composite PTransform that takes in the KV representing the coverage mean for a distinct
+   * PosRgsMq object (Position, ReadgroupsetId, and Mapping Quality) and calculates the quantiles
+   * such that 10% of the ReadGroupSetIds at a given Position (bucket) and mapping quality
+   * have at least this much coverage, and the same for 20%, etc., all the way up until 90%. It puts
+   * this into a KV object that can later be used to create annotations of the results.
+   *
+   * The percentiles will change based on the number of quantiles specified (see class description).
+   */
+  public static class CalculateQuantiles extends PTransform<PCollection<KV<PosRgsMq, Double>>,
+      PCollection<KV<Position, KV<PosRgsMq.MappingQuality, List<Double>>>>> {
+
+    private final int numQuantiles;
+
+    public CalculateQuantiles(int numQuantiles) {
+      this.numQuantiles = numQuantiles;
+    }
+
+    @Override
+    public PCollection<KV<Position, KV<PosRgsMq.MappingQuality, List<Double>>>> apply(
+        PCollection<KV<PosRgsMq, Double>> input) {
+      return input.apply(ParDo.of(new RemoveRgsId()))
+          .apply(ApproximateQuantiles
+              .<KV<Position, PosRgsMq.MappingQuality>, Double>perKey(numQuantiles))
+          .apply(ParDo.of(new MoveMapping()));
+    }
+  }
+
+  static class RemoveRgsId extends DoFn<KV<PosRgsMq, Double>,
+      KV<KV<Position, PosRgsMq.MappingQuality>, Double>> {
+
+    @Override
+    public void processElement(ProcessContext c) {
+      KV ans = KV.of(KV.of(c.element().getKey().getPos(), c.element().getKey().getMq()),
+          c.element().getValue());
+      c.output(ans);
+    }
+  }
+
+  static class MoveMapping extends DoFn<KV<KV<Position, PosRgsMq.MappingQuality>, List<Double>>,
+      KV<Position, KV<PosRgsMq.MappingQuality, List<Double>>>> {
+
+    @Override
+    public void processElement(ProcessContext c) {
+      KV ans = KV.of(c.element().getKey().getKey(),
+          KV.of(c.element().getKey().getValue(), c.element().getValue()));
+      c.output(ans);
+    }
+  }
+
+  /*
+  TODO: If a particular batchCreateAnnotations request fails more than 4 times and the bundle gets
+  retried by the dataflow pipeline, some annotations may be written multiple times.
+  */
+  static class CreateAnnotations extends
+      DoFn<KV<Position, Iterable<KV<PosRgsMq.MappingQuality, List<Double>>>>, Annotation> {
+
+    private final String asId;
+    private final GenomicsFactory.OfflineAuth auth;
+    private final List<Annotation> currAnnotations;
+    private final boolean write;
+
+    public CreateAnnotations(String asId, GenomicsFactory.OfflineAuth auth, boolean write) {
+      this.asId = asId;
+      this.auth = auth;
+      this.currAnnotations = Lists.newArrayList();
+      this.write = write;
+    }
+
+    @Override
+    public void processElement(ProcessContext c) throws GeneralSecurityException, IOException {
+      CoverageOptions pOptions = c.getPipelineOptions().as(CoverageOptions.class);
+      Position bucket = c.element().getKey();
+      Annotation a = new Annotation()
+          .setAnnotationSetId(asId)
+          .setPosition(new RangePosition()
+              .setStart(bucket.getPosition())
+              .setEnd(bucket.getPosition() + pOptions.getBucketWidth())
+              .setReferenceName(bucket.getReferenceName()))
+          .setType("GENERIC")
+          .setInfo(new HashMap<String, List<String>>());
+      for (KV<PosRgsMq.MappingQuality, List<Double>> p : c.element().getValue()) {
+        List<String> output = Lists.newArrayList();
+        for (int i = 0; i < p.getValue().size(); i++) {
+          double value = Math.round(p.getValue().get(i) * 1000000.0) / 1000000.0;
+          output.add(Double.toString(value));
+        }
+        a.getInfo().put(p.getKey().toString(), output);
+      }
+      if (write) {
+        currAnnotations.add(a);
+        if (currAnnotations.size() == 4096) {
+          // Batch create annotations once we hit the max amount for a batch
+          batchCreateAnnotations();
+        }
+      }
+      c.output(a);
+    }
+
+    @Override
+    public void finishBundle(Context c) throws IOException, GeneralSecurityException {
+      // Finish up any leftover annotations at the end.
+      if (write && !currAnnotations.isEmpty()) {
+        batchCreateAnnotations();
+      }
+    }
+
+    private void batchCreateAnnotations() throws IOException, GeneralSecurityException {
+      Genomics.Annotations.BatchCreate aRequest = auth.getGenomics(auth.getDefaultFactory())
+          .annotations().batchCreate(
+              new BatchCreateAnnotationsRequest().setAnnotations(currAnnotations));
+      RetryPolicy retryP = RetryPolicy.nAttempts(4);
+      retryP.execute(aRequest);
+      currAnnotations.clear();
+    }
+  }
+
+  private static List<String> getReadGroupSetIds() throws IOException, GeneralSecurityException {
+    if (options.getInputDatasetId().isEmpty()) { // using ReadGroupSetIds
+      String s = options.getReadGroupSetIds();
+      return Lists.newArrayList(s.split(","));
+    } else { // using InputDatasetId
+      List<String> output = Lists.newArrayList();
+      String datasetId = options.getInputDatasetId();
+      Iterable<ReadGroupSet> rgs = Paginator.ReadGroupSets.create(
+          auth.getGenomics(auth.getDefaultFactory()))
+          .search(new SearchReadGroupSetsRequest().setDatasetIds(Lists.newArrayList(datasetId)),
+              "readGroupSets/id,nextPageToken");
+      for (ReadGroupSet r : rgs) {
+        output.add(r.getId());
+      }
+      if (output.isEmpty()) {
+        throw new IOException("InputDataset does not contain any ReadGroupSets");
+      }
+      return output;
+    }
+  }
+
+  private static String checkReferenceSetIds(List<String> readGroupSetIds)
+      throws GeneralSecurityException, IOException {
+    String referenceSetId = null;
+    for (String rgsId : readGroupSetIds) {
+      Genomics.Readgroupsets.Get rgsRequest = auth.getGenomics(auth.getDefaultFactory())
+          .readgroupsets().get(rgsId).setFields("referenceSetId");
+      ReadGroupSet rgs = rgsRequest.execute();
+      if (referenceSetId == null) {
+        referenceSetId = rgs.getReferenceSetId();
+      } else if (!rgs.getReferenceSetId().equals(referenceSetId)) {
+        throw new IllegalArgumentException("ReferenceSetIds must be the same for all"
+          + " ReadGroupSets in given input.");
+      }
+    }
+    return referenceSetId;
+  }
+
+  private static AnnotationSet createAnnotationSet(String referenceSetId)
+      throws GeneralSecurityException, IOException {
+    if (referenceSetId == null) {
+      throw new IOException("ReferenceSetId was null for this readgroupset");
+    }
+    // Create a new annotation set using the given datasetId, or the one that this data was from if
+    // one was not provided
+    AnnotationSet as = new AnnotationSet();
+    if (options.getOutputDatasetId().isEmpty() && options.getInputDatasetId().isEmpty()) {
+      as.setDatasetId(options.getDatasetId());
+    } else if (options.getOutputDatasetId().isEmpty()) {
+      as.setDatasetId(options.getInputDatasetId());
+    } else {
+      as.setDatasetId(options.getOutputDatasetId());
+    }
+    if (!options.isAllReferences()) {
+      as.setName("Read Depth for " + options.getReferences());
+    } else {
+      as.setName("Read Depth");
+    }
+    as.setReferenceSetId(referenceSetId);
+    as.setType("GENERIC");
+    Genomics.AnnotationSets.Create asRequest = auth.getGenomics(auth.getDefaultFactory())
+        .annotationSets().create(as);
+    AnnotationSet asWithId = asRequest.execute();
+    return asWithId;
+  }
+
+  private static PCollection<Read> getReadsFromAPI(List<String> readGroupSetIds)
+      throws IOException, GeneralSecurityException {
+    List<SearchReadsRequest> requests = Lists.newArrayList();
+    for (String r : readGroupSetIds) {
+      requests.addAll(getReadRequests(options, r));
+    }
+    PCollection<SearchReadsRequest> readRequests = p.begin().apply(Create.of(requests));
+    PCollection<Read> reads = readRequests.apply(
+        ParDo.of(
+            new ReadReader(auth, Paginator.ShardBoundary.STRICT,
+                "alignments(alignment(position,cigar,mappingQuality),readGroupSetId)"
+                + ",nextPageToken"))
+        .named(ReadReader.class.getSimpleName()));
+    return reads;
+  }
+
+  private static List<SearchReadsRequest> getReadRequests(CoverageOptions options,
+      final String readGroupSetId) {
+    if (options.isAllReferences()) {
+      return Lists.newArrayList(new SearchReadsRequest()
+          .setReadGroupSetIds(Lists.newArrayList(readGroupSetId)));
+    }
+    final Iterable<Contig> contigs = Contig.parseContigsFromCommandLine(options.getReferences());
+    return FluentIterable.from(contigs)
+        .transformAndConcat(new Function<Contig, Iterable<Contig>>() {
+          @Override
+          public Iterable<Contig> apply(Contig contig) {
+            return contig.getShards();
+          }
+        }).transform(new Function<Contig, SearchReadsRequest>() {
+          @Override
+          public SearchReadsRequest apply(Contig shard) {
+            return shard.getReadsRequest(readGroupSetId);
+          }
+        }).toList();
+  }
+}

--- a/src/main/java/com/google/cloud/genomics/dataflow/pipelines/PosRgsMq.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/pipelines/PosRgsMq.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2015 Google.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.genomics.dataflow.pipelines;
+
+import com.google.api.client.json.GenericJson;
+import com.google.api.client.util.Key;
+import com.google.api.client.util.Value;
+import com.google.api.services.genomics.model.Position;
+import com.google.cloud.dataflow.sdk.coders.AvroCoder;
+import com.google.cloud.dataflow.sdk.coders.DefaultCoder;
+import com.google.cloud.genomics.dataflow.coders.GenericJsonCoder;
+import java.util.Objects;
+
+/**
+ * Wrapper class for Position, ReadGroupSetId and mapping quality objects for use in the
+ * CalculateCoverage pipeline
+ */
+@DefaultCoder(GenericJsonCoder.class)
+public class PosRgsMq extends GenericJson {
+
+  @Key
+  private Position pos;
+  @Key
+  private String rgsId;
+  @Key
+  private MappingQuality mq;
+
+  /**
+   * MappingQuality enum that contains the 4 possible MappingQuality types (Low(L), Medium(M),
+   * High(H), and All(A)).
+   */
+  @DefaultCoder(AvroCoder.class)
+  public enum MappingQuality {@Value L, @Value M, @Value H, @Value A}
+
+  public PosRgsMq() {
+    this.pos = new Position().setPosition(0L).setReferenceName("");
+    this.rgsId = "";
+    this.mq = MappingQuality.A;
+  }
+
+  public PosRgsMq(Position pos, String rgsId, MappingQuality mq) {
+    this.pos = pos;
+    this.rgsId = rgsId;
+    this.mq = mq;
+  }
+
+  public Position getPos() {
+    return pos;
+  }
+
+  public void setPos(Position pos) {
+    this.pos = pos;
+  }
+
+  public String getRgsId() {
+    return rgsId;
+  }
+
+  public void setRgsId(String rgsId) {
+    this.rgsId = rgsId;
+  }
+
+  public MappingQuality getMq() {
+    return mq;
+  }
+
+  public void setMq(MappingQuality mq) {
+    this.mq = mq;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == null) {
+      return false;
+    }
+    if (o == this) {
+      return true;
+    }
+    if (!(o instanceof PosRgsMq)) {
+      return false;
+    }
+    PosRgsMq test = (PosRgsMq) o;
+    return test.pos.equals(this.pos) && test.rgsId.equals(this.rgsId) && test.mq.equals(this.mq);
+  }
+
+  @Override
+  public int hashCode() {
+    int hash = 7;
+    hash = 19 * hash + Objects.hashCode(this.pos);
+    hash = 19 * hash + Objects.hashCode(this.rgsId);
+    hash = 19 * hash + Objects.hashCode(this.mq);
+    return hash;
+  }
+
+  @Override
+  public PosRgsMq set(String fieldName, Object value) {
+    return (PosRgsMq) super.set(fieldName, value);
+  }
+
+  @Override
+  public PosRgsMq clone() {
+    return (PosRgsMq) super.clone();
+  }
+}

--- a/src/test/java/com/google/cloud/genomics/dataflow/pipelines/CalculateCoverageTest.java
+++ b/src/test/java/com/google/cloud/genomics/dataflow/pipelines/CalculateCoverageTest.java
@@ -1,0 +1,307 @@
+/*
+ * Copyright 2015 Google.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.cloud.genomics.dataflow.pipelines;
+
+import com.google.api.services.genomics.model.Annotation;
+import com.google.api.services.genomics.model.CigarUnit;
+import com.google.api.services.genomics.model.LinearAlignment;
+import com.google.api.services.genomics.model.Position;
+import com.google.api.services.genomics.model.RangePosition;
+import com.google.api.services.genomics.model.Read;
+import com.google.cloud.dataflow.sdk.Pipeline;
+import com.google.cloud.dataflow.sdk.options.PipelineOptionsFactory;
+import com.google.cloud.dataflow.sdk.testing.DataflowAssert;
+import com.google.cloud.dataflow.sdk.testing.TestPipeline;
+import com.google.cloud.dataflow.sdk.transforms.Create;
+import com.google.cloud.dataflow.sdk.transforms.GroupByKey;
+import com.google.cloud.dataflow.sdk.transforms.ParDo;
+import com.google.cloud.dataflow.sdk.values.KV;
+import com.google.cloud.dataflow.sdk.values.PCollection;
+import com.google.cloud.genomics.dataflow.coders.GenericJsonCoder;
+import com.google.cloud.genomics.dataflow.pipelines.CalculateCoverage.CalculateCoverageMean;
+import com.google.cloud.genomics.dataflow.pipelines.CalculateCoverage.CalculateQuantiles;
+import com.google.cloud.genomics.dataflow.utils.DataflowWorkarounds;
+import com.google.common.collect.Lists;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+/**
+ * Class for testing the Calculate Coverage class
+ */
+@RunWith(JUnit4.class)
+public class CalculateCoverageTest {
+
+  private static List<Read> testSet;
+  private static List<KV<PosRgsMq, Double>> testSet2;
+  // The bucket width we are calculating coverage for.
+  static final int TEST_BUCKET_WIDTH = 2;
+  // The number of quantiles are are computing.
+  static final int TEST_NUM_QUANTILES = 3;
+  // The input data, see setup
+  static List<Read> input;
+  // Input read position info
+  static final long[] readPosInfo = {0, 1, 2, 0, 0, 0, 0, 2, 3, 0, 0, 0, 3, 2, 0,
+    0, 0, 0, 1, 3, 0, 0, 1, 0, 2};
+  // Input read mapping quality info, (L = 5, M = 15, H = 35)
+  static final int[] readMQInfo = {5, 15, 35, 15, 35, 5, 5, 15, 15, 35, 5, 15, 35, 35, 15,
+    5, 15, 15, 35, 35, 5, 5, 5, 5, 5};
+  // Input read length info
+  static final int[] readLengthInfo = {4, 3, 1, 3, 1, 4, 3, 2, 1, 1, 4, 2, 1, 1, 3,
+    4, 2, 1, 2, 1, 4, 3, 3, 2, 1};
+
+  @BeforeClass
+  public static void oneTimeSetUp() {
+    // Test data for testCalculateCoverageMean
+    // Read 1 (Contains two operations that result in increasing the length of the read)
+    List<CigarUnit> cigars = new ArrayList<>();
+    for (int i = 0; i < 3; i++) {
+      CigarUnit u = new CigarUnit();
+      u.setOperationLength(2L);
+      cigars.add(u);
+    }
+    cigars.get(0).setOperation("INSERT");
+    cigars.get(1).setOperation("SEQUENCE_MISMATCH");
+    cigars.get(2).setOperation("PAD");
+    Read read2ValidOps = new Read()
+        .setAlignment(new LinearAlignment()
+            .setCigar(cigars)
+            .setPosition(new Position()
+                .setPosition(3L)
+                .setReferenceName("chr1"))
+            .setMappingQuality(15))
+        .setReadGroupSetId("123");
+    // Read 2 (Contains three operations that result in increasing the length of the read)
+    cigars.clear();
+    for (int i = 0; i < 3; i++) {
+      CigarUnit u = new CigarUnit();
+      u.setOperationLength(1L);
+      cigars.add(u);
+    }
+    cigars.get(0).setOperation("DELETE");
+    cigars.get(1).setOperation("SKIP");
+    cigars.get(2).setOperation("SEQUENCE_MATCH");
+    Read read3ValidOps = new Read()
+        .setAlignment(new LinearAlignment()
+            .setCigar(cigars)
+            .setPosition(new Position()
+                .setPosition(2L)
+                .setReferenceName("chr1"))
+            .setMappingQuality(1))
+        .setReadGroupSetId("123");
+    // Read 3 (Unmapped)
+    Read unmappedRead = new Read().setAlignment(null);
+    // Read 4 (Contains one operation that results in increasing the length of the read)
+    cigars.clear();
+    for (int i = 0; i < 3; i++) {
+      CigarUnit u = new CigarUnit();
+      u.setOperationLength(4L);
+      cigars.add(u);
+    }
+    cigars.get(0).setOperation("INSERT");
+    cigars.get(1).setOperation("ALIGNMENT_MATCH");
+    cigars.get(2).setOperation("CLIP_SOFT");
+    Read read1ValidOp = new Read()
+        .setAlignment(new LinearAlignment()
+            .setCigar(cigars)
+            .setPosition(new Position()
+                .setPosition(4L)
+                .setReferenceName("chr1"))
+            .setMappingQuality(1))
+        .setReadGroupSetId("321");
+    testSet = Lists.newArrayList(read2ValidOps, read3ValidOps, unmappedRead, read1ValidOp);
+    // Test data for testCalculateQuantiles
+    testSet2 = Lists.newArrayList();
+    Position p = new Position().setPosition(1L).setReferenceName("chr1");
+    testSet2.add(KV.of(new PosRgsMq(p, "123", PosRgsMq.MappingQuality.L), 4.0));
+    testSet2.add(KV.of(new PosRgsMq(p, "123", PosRgsMq.MappingQuality.M), 2.0));
+    testSet2.add(KV.of(new PosRgsMq(p, "123", PosRgsMq.MappingQuality.H), 0.5));
+    testSet2.add(KV.of(new PosRgsMq(p, "123", PosRgsMq.MappingQuality.A), 6.5));
+    testSet2.add(KV.of(new PosRgsMq(p, "321", PosRgsMq.MappingQuality.L), 5.0));
+    testSet2.add(KV.of(new PosRgsMq(p, "321", PosRgsMq.MappingQuality.M), 1.0));
+    testSet2.add(KV.of(new PosRgsMq(p, "321", PosRgsMq.MappingQuality.H), 0.75));
+    testSet2.add(KV.of(new PosRgsMq(p, "321", PosRgsMq.MappingQuality.A), 6.75));
+    testSet2.add(KV.of(new PosRgsMq(p, "456", PosRgsMq.MappingQuality.L), 4.6));
+    testSet2.add(KV.of(new PosRgsMq(p, "456", PosRgsMq.MappingQuality.M), 3.2));
+    testSet2.add(KV.of(new PosRgsMq(p, "456", PosRgsMq.MappingQuality.H), 1.2));
+    testSet2.add(KV.of(new PosRgsMq(p, "456", PosRgsMq.MappingQuality.A), 9.0));
+    testSet2.add(KV.of(new PosRgsMq(p, "654", PosRgsMq.MappingQuality.L), 3.0));
+    testSet2.add(KV.of(new PosRgsMq(p, "654", PosRgsMq.MappingQuality.A), 3.0));
+    testSet2.add(KV.of(new PosRgsMq(p, "789", PosRgsMq.MappingQuality.L), 8.0));
+    testSet2.add(KV.of(new PosRgsMq(p, "789", PosRgsMq.MappingQuality.A), 8.0));
+    // Test data for testCalculateCoverage
+    input = Lists.newArrayList();
+    cigars.clear();
+    for (int i = 0; i < 25; i++) {
+      cigars = new ArrayList<>();
+      for (int j = 0; j < readLengthInfo[i]; j++) {
+        CigarUnit u = new CigarUnit();
+        u.setOperationLength(1L);
+        u.setOperation("ALIGNMENT_MATCH");
+        cigars.add(u);
+      }
+      Read read = new Read()
+          .setAlignment(new LinearAlignment()
+              .setCigar(cigars)
+              .setPosition(new Position()
+                  .setPosition(readPosInfo[i])
+                  .setReferenceName("1"))
+              .setMappingQuality(readMQInfo[i]))
+          .setReadGroupSetId("Rgs" + i / 5 + 1);
+      input.add(read);
+    }
+  }
+
+  /**
+   * Unit test for CalculateCoverageMean composite PTransform
+   */
+  @Test
+  public void testCalculateCoverageMean() {
+    // Expected Output
+    KV<PosRgsMq, Double>[] expectedOutput = new KV[12];
+    PosRgsMq pTest = new PosRgsMq(new Position()
+        .setPosition(2L).setReferenceName("chr1"), "123", PosRgsMq.MappingQuality.L);
+    expectedOutput[0] = KV.of(pTest, 1.0);
+    pTest = new PosRgsMq(new Position()
+        .setPosition(2L).setReferenceName("chr1"), "123", PosRgsMq.MappingQuality.M);
+    expectedOutput[1] = KV.of(pTest, 0.5);
+    pTest = new PosRgsMq(new Position()
+        .setPosition(2L).setReferenceName("chr1"), "123", PosRgsMq.MappingQuality.A);
+    expectedOutput[2] = KV.of(pTest, 1.5);
+    pTest = new PosRgsMq(new Position()
+        .setPosition(4L).setReferenceName("chr1"), "123", PosRgsMq.MappingQuality.L);
+    expectedOutput[3] = KV.of(pTest, 0.5);
+    pTest = new PosRgsMq(new Position()
+        .setPosition(4L).setReferenceName("chr1"), "123", PosRgsMq.MappingQuality.M);
+    expectedOutput[4] = KV.of(pTest, 1.0);
+    pTest = new PosRgsMq(new Position()
+        .setPosition(4L).setReferenceName("chr1"), "123", PosRgsMq.MappingQuality.A);
+    expectedOutput[5] = KV.of(pTest, 1.5);
+    pTest = new PosRgsMq(new Position()
+        .setPosition(6L).setReferenceName("chr1"), "123", PosRgsMq.MappingQuality.M);
+    expectedOutput[6] = KV.of(pTest, 0.5);
+    pTest = new PosRgsMq(new Position()
+        .setPosition(6L).setReferenceName("chr1"), "123", PosRgsMq.MappingQuality.A);
+    expectedOutput[7] = KV.of(pTest, 0.5);
+    pTest = new PosRgsMq(new Position()
+        .setPosition(4L).setReferenceName("chr1"), "321", PosRgsMq.MappingQuality.L);
+    expectedOutput[8] = KV.of(pTest, 1.0);
+    pTest = new PosRgsMq(new Position()
+        .setPosition(4L).setReferenceName("chr1"), "321", PosRgsMq.MappingQuality.A);
+    expectedOutput[9] = KV.of(pTest, 1.0);
+    pTest = new PosRgsMq(new Position()
+        .setPosition(6L).setReferenceName("chr1"), "321", PosRgsMq.MappingQuality.L);
+    expectedOutput[10] = KV.of(pTest, 1.0);
+    pTest = new PosRgsMq(new Position()
+        .setPosition(6L).setReferenceName("chr1"), "321", PosRgsMq.MappingQuality.A);
+    expectedOutput[11] = KV.of(pTest, 1.0);
+    Pipeline p = TestPipeline.create();
+    DataflowWorkarounds.registerCoder(p, PosRgsMq.class, GenericJsonCoder.of(PosRgsMq.class));
+    PCollection<Read> input = p.apply(Create.of(testSet));
+    PCollection<KV<PosRgsMq, Double>> output = input.apply(new CalculateCoverageMean());
+    DataflowAssert.that(output).containsInAnyOrder(expectedOutput);
+  }
+
+  /**
+   * Unit test for CalculateQuantiles composite PTransform
+   */
+  @Test
+  public void testCalculateQuantiles() {
+    Pipeline p = TestPipeline.create();
+    DataflowWorkarounds.registerCoder(p, Position.class, GenericJsonCoder.of(Position.class));
+    DataflowWorkarounds.registerCoder(p, PosRgsMq.class, GenericJsonCoder.of(PosRgsMq.class));
+    PCollection<KV<PosRgsMq, Double>> input = p.apply(Create.of(testSet2));
+    PCollection<KV<Position, KV<PosRgsMq.MappingQuality, List<Double>>>> output = input.apply(
+        new CalculateQuantiles(3));
+    Position pos = new Position().setPosition(1L).setReferenceName("chr1");
+    List<Double> low = Lists.newArrayList(3.0, 4.6, 8.0);
+    List<Double> med = Lists.newArrayList(1.0, 2.0, 3.2);
+    List<Double> high = Lists.newArrayList(0.5, 0.75, 1.2);
+    List<Double> all = Lists.newArrayList(3.0, 6.75, 9.0);
+    DataflowAssert.that(output).containsInAnyOrder(
+        KV.of(pos, KV.of(PosRgsMq.MappingQuality.L, low)),
+        KV.of(pos, KV.of(PosRgsMq.MappingQuality.M, med)),
+        KV.of(pos, KV.of(PosRgsMq.MappingQuality.H, high)),
+        KV.of(pos, KV.of(PosRgsMq.MappingQuality.A, all)));
+  }
+
+  /**
+   * Testing the CalculateCoverage pipeline.
+   */
+  @Test
+  public void testCalculateCoverage() throws Exception {
+    List<Annotation> expectedOutput = Lists.newArrayList();
+    Annotation a1 = new Annotation()
+        .setAnnotationSetId("123")
+        .setPosition(new RangePosition()
+            .setStart(0L)
+            .setEnd(2L)
+            .setReferenceName("1"))
+        .setType("GENERIC")
+        .setInfo(new HashMap<String, List<String>>());
+    a1.getInfo().put("L", Lists.newArrayList("1.0", "1.0", "3.5"));
+    a1.getInfo().put("M", Lists.newArrayList("1.5", "1.5", "2.0"));
+    a1.getInfo().put("H", Lists.newArrayList("0.5", "0.5", "0.5"));
+    a1.getInfo().put("A", Lists.newArrayList("2.5", "3.0", "3.5"));
+    expectedOutput.add(a1);
+    Annotation a2 = new Annotation()
+        .setAnnotationSetId("123")
+        .setPosition(new RangePosition()
+            .setStart(2L)
+            .setEnd(4L)
+            .setReferenceName("1"))
+        .setType("GENERIC")
+        .setInfo(new HashMap<String, List<String>>());
+    a2.getInfo().put("L", Lists.newArrayList("1.0", "1.0", "3.0"));
+    a2.getInfo().put("M", Lists.newArrayList("0.5", "1.5", "1.5"));
+    a2.getInfo().put("H", Lists.newArrayList("0.5", "1.0", "1.0"));
+    a2.getInfo().put("A", Lists.newArrayList("2.0", "3.0", "3.0"));
+    expectedOutput.add(a2);
+    CalculateCoverage.CoverageOptions popts = PipelineOptionsFactory.create().as(
+        CalculateCoverage.CoverageOptions.class);
+    popts.setBucketWidth(TEST_BUCKET_WIDTH);
+    popts.setNumQuantiles(TEST_NUM_QUANTILES);
+    Pipeline p = TestPipeline.create(popts);
+    DataflowWorkarounds.registerCoder(p, Read.class, GenericJsonCoder.of(Read.class));
+    DataflowWorkarounds.registerCoder(p, Position.class, GenericJsonCoder.of(Position.class));
+    DataflowWorkarounds.registerCoder(p, PosRgsMq.class, GenericJsonCoder.of(PosRgsMq.class));
+    DataflowWorkarounds.registerCoder(p, Annotation.class, GenericJsonCoder.of(Annotation.class));
+
+    PCollection<Read> reads = p.apply(Create.of(input));
+    PCollection<KV<PosRgsMq, Double>> coverageMeans = reads.apply(
+        new CalculateCoverage.CalculateCoverageMean());
+
+    PCollection<KV<Position, KV<PosRgsMq.MappingQuality, List<Double>>>> quantiles
+        = coverageMeans.apply(new CalculateCoverage.CalculateQuantiles(popts.getNumQuantiles()));
+
+    PCollection<KV<Position, Iterable<KV<PosRgsMq.MappingQuality, List<Double>>>>> answer
+        = quantiles.apply(GroupByKey.<Position, KV<PosRgsMq.MappingQuality, List<Double>>>create());
+
+    PCollection<Annotation> output = answer.apply(
+        ParDo.of(new CalculateCoverage.CreateAnnotations("123", null, false)));
+
+    DataflowAssert.that(output).containsInAnyOrder(expectedOutput);
+
+    p.run();
+
+  }
+}


### PR DESCRIPTION
Pipeline for calculating read depth coverage for a given data set, with unit tests.

For each "bucket" in the given input references, this computes the average coverage (rounded to
six decimal places) across the bucket that 10%, 20%, 30%, etc. of the input ReadGroupsSets have
for each mapping quality of the reads (<10:Low(L), 10-29:Medium(M), >=30:High(H)) as well as
these same percentiles of ReadGroupSets for all reads regardless of mapping quality (Mapping
quality All(A)).

There is also the option to change the number of quantiles accordingly (numQuantiles = 5 would
give you the minimum ReadGroupSet mean coverage for each and across all mapping qualities, the
25th, 50th, and 75th percentiles, and the maximum of these values).