### PR TITLE
Use Dataflow's oauth flow.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
     <dependency>
       <groupId>com.google.cloud.genomics</groupId>
       <artifactId>google-genomics-utils</artifactId>
-      <version>v1beta2-0.25</version>
+      <version>v1beta2-0.26</version>
       <exclusions>
         <!-- Exclude an old version of guava which is being pulled
              in by a transitive dependency google-api-client 1.19.0 -->

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
     <dependency>
       <groupId>com.google.cloud.genomics</groupId>
       <artifactId>google-genomics-utils</artifactId>
-      <version>v1beta2-0.26</version>
+      <version>v1beta2-0.27</version>
       <exclusions>
         <!-- Exclude an old version of guava which is being pulled
              in by a transitive dependency google-api-client 1.19.0 -->

--- a/src/main/java/com/google/cloud/genomics/dataflow/utils/GCSHelper.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/utils/GCSHelper.java
@@ -62,7 +62,8 @@ public class GCSHelper {
     httpTransport = factory.getHttpTransport();
     Storage.Builder builder = new Storage.Builder(httpTransport, JSON_FACTORY, null)
         .setApplicationName(popts.getAppName());
-    storage = factory.getOfflineAuth(popts.getApiKey(), popts.getSecretsFile()).setupAuthentication(factory, builder).build();
+    GenomicsFactory.OfflineAuth auth = GenomicsOptions.Methods.getGenomicsAuth(popts);
+    storage = auth.setupAuthentication(factory, builder).build();
   }
 
   /**
@@ -95,9 +96,8 @@ public class GCSHelper {
     GenomicsFactory factory = GenomicsFactory.builder(appName)
         .setScopes(Lists.newArrayList(DEVSTORAGE_READ_ONLY, GenomicsScopes.GENOMICS))
         .build();
-    JacksonFactory jsonFactory = JacksonFactory.getDefaultInstance();
     httpTransport = factory.getHttpTransport();
-    GenomicsFactory.OfflineAuth offlineAuth = factory.getOfflineAuth(null, secretsFile);
+    GenomicsFactory.OfflineAuth offlineAuth = factory.getOfflineAuthFromClientSecretsFile(secretsFile);
     Storage.Builder builder = new Storage.Builder(httpTransport, JSON_FACTORY, null)
         .setApplicationName(appName);
     storage = offlineAuth.setupAuthentication(factory, builder).build();

--- a/src/main/java/com/google/cloud/genomics/dataflow/utils/GCSOptions.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/utils/GCSOptions.java
@@ -28,10 +28,10 @@ import com.google.cloud.dataflow.sdk.options.PipelineOptions;
 import com.google.cloud.dataflow.sdk.transforms.DoFn;
 import com.google.cloud.genomics.utils.GenomicsFactory;
 import com.google.common.collect.ImmutableList;
-
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import java.io.IOException;
+import java.security.GeneralSecurityException;
 import java.util.List;
 import java.util.logging.Logger;
 
@@ -114,10 +114,8 @@ public interface GCSOptions extends GenomicsOptions {
     }
     
     public static GenomicsFactory.OfflineAuth createGCSAuth(GCSOptions options)
-      throws IOException {
-      return options
-              .getGenomicsFactory()
-              .getOfflineAuth(options.getApiKey(), options.getSecretsFile());
+      throws IOException, GeneralSecurityException {
+      return GenomicsOptions.Methods.getGenomicsAuth(options);
     }
     
     public static Storage.Objects createStorageClient(

--- a/src/main/java/com/google/cloud/genomics/dataflow/utils/GenomicsOptions.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/utils/GenomicsOptions.java
@@ -13,18 +13,14 @@
  */
 package com.google.cloud.genomics.dataflow.utils;
 
-import com.google.api.client.extensions.java6.auth.oauth2.VerificationCodeReceiver;
-import com.google.api.client.googleapis.extensions.java6.auth.oauth2.GooglePromptReceiver;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+
 import com.google.cloud.dataflow.sdk.options.DataflowPipelineOptions;
 import com.google.cloud.dataflow.sdk.options.Default;
 import com.google.cloud.dataflow.sdk.options.Description;
 import com.google.cloud.genomics.utils.GenomicsFactory;
 import com.google.cloud.genomics.utils.GenomicsFactory.Builder;
-import com.google.common.base.Supplier;
-import com.google.common.base.Suppliers;
-
-import java.io.IOException;
-import java.security.GeneralSecurityException;
 
 /**
  * Contains common genomics pipeline options. Extend this class to add additional command line args.
@@ -33,28 +29,30 @@ import java.security.GeneralSecurityException;
  * annotated with a @JsonIgnore annotation.
  */
 public interface GenomicsOptions extends DataflowPipelineOptions {
+  
+  // Use the same appName for all pipelines in this collection so that the oauth flow only needs to happen once.
+  public static final String APP_NAME = "dataflow-java";
 
   public static class Methods {
-    public static GenomicsFactory.OfflineAuth getGenomicsAuth(GenomicsOptions options)
-        throws IOException, GeneralSecurityException {
-      String apiKey = options.getApiKey(), appName = options.getAppName();
-      Supplier<? extends VerificationCodeReceiver> verificationCodeReceiver =
-          Suppliers.ofInstance(new GooglePromptReceiver());
+    
+    public static GenomicsFactory.OfflineAuth getGenomicsAuth(GenomicsOptions options) throws GeneralSecurityException, IOException {
       Builder builder =
-          GenomicsFactory.builder(appName).setNumberOfRetries(options.getNumberOfRetries());
+          GenomicsFactory.builder(APP_NAME).setNumberOfRetries(options.getNumberOfRetries());
 
-      if (options.isNoLaunchBrowser()) {
-        builder.setVerificationCodeReceiver(verificationCodeReceiver);
-      }
-      return builder.build().getOfflineAuth(apiKey, options.getSecretsFile());
-    }
-
-    public static void validateOptions(GenomicsOptions options) {
       String secretsFile = options.getSecretsFile(), apiKey = options.getApiKey();
       if (secretsFile == null && apiKey == null) {
         throw new IllegalArgumentException(
             "Need to specify either --secretsFile or --apiKey");
       }
+
+      if(null != secretsFile) {
+        return builder.build().getOfflineAuthFromCredential(options.getGcpCredential(),
+              secretsFile);
+      }
+      return builder.build().getOfflineAuthFromApiKey(apiKey);
+    }
+
+    public static void validateOptions(GenomicsOptions options) {
     }
   }
 
@@ -76,10 +74,4 @@ public interface GenomicsOptions extends DataflowPipelineOptions {
   int getPageSize();
 
   void setPageSize(int pageSize);
-
-  // Modeled after gcloud auth login --no-launch-browser
-  @Description("Print a URL to be copied instead of launching a web browser for the authorization flow.")
-  @Default.Boolean(false)
-  boolean isNoLaunchBrowser();
-  void setNoLaunchBrowser(boolean noLaunchBrowser);
 }

--- a/src/main/java/com/google/cloud/genomics/dataflow/utils/GenomicsOptions.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/utils/GenomicsOptions.java
@@ -29,15 +29,12 @@ import com.google.cloud.genomics.utils.GenomicsFactory.Builder;
  * annotated with a @JsonIgnore annotation.
  */
 public interface GenomicsOptions extends DataflowPipelineOptions {
-  
-  // Use the same appName for all pipelines in this collection so that the oauth flow only needs to happen once.
-  public static final String APP_NAME = "dataflow-java";
 
   public static class Methods {
-    
+
     public static GenomicsFactory.OfflineAuth getGenomicsAuth(GenomicsOptions options) throws GeneralSecurityException, IOException {
       Builder builder =
-          GenomicsFactory.builder(APP_NAME).setNumberOfRetries(options.getNumberOfRetries());
+          GenomicsFactory.builder(options.getAppName()).setNumberOfRetries(options.getNumberOfRetries());
 
       String secretsFile = options.getSecretsFile(), apiKey = options.getApiKey();
       if (secretsFile == null && apiKey == null) {


### PR DESCRIPTION
1. Fixes https://github.com/googlegenomics/dataflow-java/issues/95
1. Depends on https://github.com/googlegenomics/utils-java/pull/33
1. Using same appname for all dataflow-java pipelines with OfflineAuth created via GenomicsOptions.Methods.getGenomicsAuth so that we only have to do oauth once when trying a few different pipelines.  (we have it this way in spark-examples too
1. Removes now unnecessary flag for headless operation.

Tested via:
* mvn verify
* dataflow pipelines CountReads and VariantSimilarity kicked off from local machine
* dataflow pipelines CountReads and VariantSimilarity kicked off from GCE (headless)

@iliat I think https://github.com/googlegenomics/dataflow-java/blob/master/src/main/java/com/google/cloud/genomics/dataflow/utils/GCSOptions.java is mostly obsolete now that Dataflow oauth flow includes the cloud platform scope which covers GCS and Google Genomics.  Also, could use a rename - it doesn't add any new options, just makes it convenient to get a GCS client.