### PR TITLE
.toString doesn't work for all encodings of attributes (ReadConverter)

### DIFF
--- a/src/main/java/com/google/cloud/genomics/dataflow/readers/bam/ReadConverter.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/readers/bam/ReadConverter.java
@@ -126,7 +126,14 @@ public class ReadConverter {
 
     Map<String, List<String>> attributes = Maps.newHashMap();
     for( SAMRecord.SAMTagAndValue tagAndValue: record.getAttributes()) {
-      attributes.put(tagAndValue.tag, Lists.newArrayList(tagAndValue.value.toString()));
+      String s = tagAndValue.value.toString();
+      if (tagAndValue.value instanceof byte[]) {
+        // It's possible for client code of SamRecord to pass byte[]
+        // to setAttribute. toString is not defined for byte[], so
+        // it produces garbage. The solution to create a string directly.
+        s = new String(((byte[]) tagAndValue.value));
+      }
+      attributes.put(tagAndValue.tag, Lists.newArrayList(s));
     }
     read.setInfo(attributes);
 

--- a/src/test/java/com/google/cloud/genomics/dataflow/readers/bam/ReadConverterTest.java
+++ b/src/test/java/com/google/cloud/genomics/dataflow/readers/bam/ReadConverterTest.java
@@ -38,6 +38,24 @@ public class ReadConverterTest {
     assertEquals("chr20", read.getNextMatePosition().getReferenceName());
     assertEquals((Boolean)true, read.getNextMatePosition().getReverseStrand());
   }
+  @Test
+  public void testByteArrayAttributes() {
+    // Client code of SamRecord can pass anything to setAttribute including
+    // byte[] (which doesn't have toString defined). This verifies
+    // we handle that case correctly.
+    SAMRecord record = new SAMRecord(null);
+    record.setReferenceName("chr20");
+    record.setAlignmentStart(1);
+    record.setCigarString(String.format("%dM", 10));
+    String s = "123456";
+    record.setAttribute("FZ", s.getBytes());
+
+    Read read = ReadConverter.makeRead(record);
+    assertEquals((long)0, (long)read.getAlignment().getPosition().getPosition());
+    assertEquals((long)1, (long)read.getAlignment().getCigar().size());
+    assertEquals("chr20", read.getAlignment().getPosition().getReferenceName());
+    assertEquals(s, read.getInfo().get("FZ").get(0));
+  }
 
   @Test
   public void SamToReadToSamTest() throws IOException {


### PR DESCRIPTION
The root cause of the problem is that many clients that create SamRecords set byte array attributes (instead of just string attributes). .toString() is not defined for byte arrays, so garbage is produced instead. The correct way to handle this is to use String() instead.

This bug was sent my way from an engineer at the Broad. 
