### PR TITLE
Adding option to read unmapped reads as expected by GATK/Picard

### DIFF
--- a/src/main/java/com/google/cloud/genomics/dataflow/readers/bam/Reader.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/readers/bam/Reader.java
@@ -44,22 +44,48 @@ public class Reader {
   BAMShard shard;
   DoFn<BAMShard, Read>.ProcessContext c;
   Stopwatch timer;
-  ValidationStringency stringency;
+  ReaderOptions options;
   
   SAMRecordIterator iterator;
-  boolean procesingUnmapped;
+  enum Filter {
+    UNMAPPED_ONLY,
+    MAPPED_AND_UNMAPPED,
+    MAPPED_ONLY
+  }
+  
+  Filter filter;
   
   int recordsBeforeStart = 0;
   int recordsAfterEnd = 0;
   int mismatchedSequence = 0;
   int recordsProcessed = 0;
   
-  public Reader(Objects storageClient, ValidationStringency stringency, BAMShard shard, DoFn<BAMShard, Read>.ProcessContext c) {
+  public Reader(Objects storageClient, ReaderOptions options, BAMShard shard, DoFn<BAMShard, Read>.ProcessContext c) {
     super();
     this.storageClient = storageClient;
     this.shard = shard;
     this.c = c;
-    this.stringency = stringency;
+    this.options = options;
+    filter = setupFilter(options, shard.contig.referenceName);
+  }
+  
+  public static Filter setupFilter(ReaderOptions options, String referenceName) {
+    /* 
+     * The common way of asking for unmapped reads is by specifying asterisk
+     * as the sequence name.
+     * From SAM format, section 1.4. paragraph 3:
+     * "RNAME: Reference sequence NAME of the alignment. 
+     * If @SQ header lines are present, RNAME (if not ‘*’) must be present in 
+     * one of the SQ-SN tag. 
+     * An unmapped segment without coordinate has a ‘*’ at this field."
+     * https://samtools.github.io/hts-specs/SAMv1.pdf
+     */
+    if (referenceName.equals("*")) {
+      return Filter.UNMAPPED_ONLY;
+    } else if (options.getIncludeUnmappedReads()) {
+      return Filter.MAPPED_AND_UNMAPPED;
+    }
+    return Filter.MAPPED_ONLY;
   }
   
   public void process() throws IOException {
@@ -75,11 +101,11 @@ public class Reader {
 
   void openFile() throws IOException {
     LOG.info("Processing shard " + shard);
-    final SamReader reader = BAMIO.openBAM(storageClient, shard. file, stringency);
+    final SamReader reader = BAMIO.openBAM(storageClient, shard.file, 
+        options.getStringency());
     iterator = null;
-    procesingUnmapped = shard.contig.referenceName.equals("*");
     if (reader.hasIndex() && reader.indexing() != null) {
-      if (procesingUnmapped) {
+      if (filter == Filter.UNMAPPED_ONLY) {
         LOG.info("Processing unmapped");
         iterator = reader.queryUnmapped();
       } else if (shard.span != null) {
@@ -97,16 +123,43 @@ public class Reader {
     }
   }
 
-  boolean isWrongSequence(SAMRecord record) {
-    return (procesingUnmapped && !record.getReadUnmappedFlag()) ||
-        (!procesingUnmapped && (record.getReadUnmappedFlag() || 
-            (shard.contig.referenceName != null && 
-            !shard.contig.referenceName.isEmpty() &&
-            !shard.contig.referenceName.equals(record.getReferenceName()))));
+  /**
+   * Checks if the record matches our filter.
+   */
+  static boolean passesFilter(SAMRecord record, Filter filter, 
+      String referenceName) {
+    // If we are looking for only mapped or only unmapped reads then we will use
+    // the UnmappedFlag to decide if this read should be rejected.
+    if (filter == Filter.UNMAPPED_ONLY && !record.getReadUnmappedFlag()) {
+      return false;
+    }
+    
+    if (filter == Filter.MAPPED_ONLY && record.getReadUnmappedFlag()) {
+      return false;
+    }
+    
+    // If we are looking for mapped reads, then we check the reference name
+    // of the read matches the one we are looking for.
+    final boolean referenceNameMismatch = referenceName != null && 
+        !referenceName.isEmpty() &&
+        !referenceName.equals(record.getReferenceName());
+    
+    // Note that unmapped mate pair of mapped read will have a reference
+    // name set to the reference of its mapped mate.
+    if ((filter == Filter.MAPPED_ONLY || filter == Filter.MAPPED_AND_UNMAPPED)
+        && referenceNameMismatch) {
+      return false;
+    }
+    
+    return true;
+  }
+  
+  boolean passesFilter(SAMRecord record) {
+    return passesFilter(record, filter, shard.contig.referenceName);
   }
   
   void processRecord(SAMRecord record) {
-    if (isWrongSequence(record)) {
+    if (!passesFilter(record)) {
       mismatchedSequence++;
       return;
     }
@@ -138,9 +191,11 @@ public class Reader {
    * This makes it easier to discover errors such as reads that are somehow
    * skipped by a sharded approach.
    */
-  public static Iterable<Read> readSequentiallyForTesting(Objects storageClient, String storagePath, Contig contig, ValidationStringency stringency) throws IOException {
+  public static Iterable<Read> readSequentiallyForTesting(Objects storageClient,
+      String storagePath, Contig contig, 
+      ReaderOptions options) throws IOException {
     Stopwatch timer = Stopwatch.createStarted();
-    SamReader samReader = BAMIO.openBAM(storageClient, storagePath, stringency);
+    SamReader samReader = BAMIO.openBAM(storageClient, storagePath, options.getStringency());
     SAMRecordIterator iterator =  samReader.queryOverlapping(contig.referenceName, 
         (int) contig.start + 1,
         (int) contig.end + 1);
@@ -150,12 +205,12 @@ public class Reader {
     int recordsAfterEnd = 0;
     int mismatchedSequence = 0;
     int recordsProcessed = 0;
+    Filter filter = setupFilter(options, contig.referenceName);
     while (iterator.hasNext()) {
       SAMRecord record = iterator.next();
-      final boolean wrongSequence = !contig.referenceName.equals(record.getReferenceName())
-          || (!contig.referenceName.equals("*") && record.getReadUnmappedFlag());
+      final boolean passesFilter = passesFilter(record, filter, contig.referenceName);
       
-      if (wrongSequence) {
+      if (!passesFilter) {
         mismatchedSequence++;
         continue;
       }

--- a/src/main/java/com/google/cloud/genomics/dataflow/readers/bam/ReaderOptions.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/readers/bam/ReaderOptions.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.cloud.genomics.dataflow.readers.bam;
+
+import htsjdk.samtools.ValidationStringency;
+
+import java.io.Serializable;
+
+/**
+ * A collection of options governing how BAM files are read.
+ */
+public class ReaderOptions implements Serializable{
+  ValidationStringency stringency = ValidationStringency.DEFAULT_STRINGENCY;
+  
+  /**
+   * If true, we will read and return unmapped reads in the order expected by
+   * HTSDK/GATK/Picard tools, specifically unmapped mate pairs of mapped reads
+   * will be returned according to their position specified in the BAM record
+   * (as opposed to being after all the mapped reads). This position is 
+   * typically specified such that these unmapped mates immediately follow 
+   * their mapped counterparts. 
+   */
+  boolean includeUnmappedReads = false;
+  
+  public ReaderOptions() {
+    
+  }
+  
+  public ReaderOptions(ValidationStringency stringency, boolean includeUnmappedReads) {
+    this.stringency = stringency;
+    this.includeUnmappedReads = includeUnmappedReads;
+  }
+
+  public ValidationStringency getStringency() {
+    return stringency;
+  }
+  
+  public void setStringency(ValidationStringency stringency) {
+    this.stringency = stringency;
+  }
+  
+  public boolean getIncludeUnmappedReads() {
+    return includeUnmappedReads;
+  }
+  
+  public void setIncludeUnmappedReads(boolean includeUnmappedReads) {
+    this.includeUnmappedReads = includeUnmappedReads;
+  }
+}
+

--- a/src/test/java/com/google/cloud/genomics/dataflow/pipelines/CountReadsITCase.java
+++ b/src/test/java/com/google/cloud/genomics/dataflow/pipelines/CountReadsITCase.java
@@ -49,11 +49,16 @@ public class CountReadsITCase {
   final String TEST_CONTIG = "1:550000:560000";
   // How many reads are in that region.
   final long TEST_EXPECTED = 685;
+  // In this file there are no unmapped reads, so expecting the same number.
+  final long TEST_EXPECTED_WITH_UNMAPPED = TEST_EXPECTED;
+  
   // Same as the above variables, but for the NA12877_S1 dataset.
   final String NA12877_S1_BAM_FILENAME = "gs://genomics-public-data/platinum-genomes/bam/NA12877_S1.bam";
   final String NA12877_S1_READGROUPSET = "CMvnhpKTFhD3he72j4KZuyc";
   final String NA12877_S1_CONTIG = "chr17:41196311:41277499";
   final long NA12877_S1_EXPECTED = 45081;
+  // How many reads are in that region if we take unmapped ones too    
+  final long NA12877_S1_EXPECTED_WITH_UNMAPPED = 45142;
 
   @Before
   public void voidEnsureEnvVar() {
@@ -67,13 +72,15 @@ public class CountReadsITCase {
     // we don't care how TEST_STAGING_GCS_FOLDER ends, so no check for it.
   }
   
-  private void testLocalBase(String outputFilename, String contig, String bamFilename, long expectedCount) throws Exception {
+  private void testLocalBase(String outputFilename, String contig, String bamFilename, long expectedCount,
+      boolean includeUnmapped) throws Exception {
     final String OUTPUT = TEST_OUTPUT_GCS_FOLDER + outputFilename;
     String[] ARGS = {
         "--apiKey=" + API_KEY,
         "--project=" + TEST_PROJECT,
         "--output=" + OUTPUT,
         "--references=" + contig,
+        "--includeUnmapped=" + includeUnmapped,
         "--BAMFilePath=" + bamFilename,
     };
     GenomicsOptions popts = PipelineOptionsFactory.create().as(GenomicsOptions.class);
@@ -99,13 +106,26 @@ public class CountReadsITCase {
   @Test
   public void testLocal() throws Exception {
     testLocalBase("CountReadsITCase-testLocal-output.txt",
-        TEST_CONTIG, TEST_BAM_FNAME, TEST_EXPECTED);
+        TEST_CONTIG, TEST_BAM_FNAME, TEST_EXPECTED, false);
+  }
+  
+  @Test
+  public void testLocalUnmapped() throws Exception {
+    testLocalBase("CountReadsITCase-testLocal-output.txt",
+        TEST_CONTIG, TEST_BAM_FNAME, TEST_EXPECTED_WITH_UNMAPPED, true);
   }
   
   @Test
   public void testLocalNA12877_S1() throws Exception {
     testLocalBase("CountReadsITCase-testLocal-NA12877_S1-output.txt",
-        NA12877_S1_CONTIG, NA12877_S1_BAM_FILENAME, NA12877_S1_EXPECTED);
+        NA12877_S1_CONTIG, NA12877_S1_BAM_FILENAME, NA12877_S1_EXPECTED, false);
+  }
+  
+  @Test
+  public void testLocalNA12877_S1_UNMAPPED() throws Exception {
+    testLocalBase("CountReadsITCase-testLocal-NA12877_S1-output.txt",
+        NA12877_S1_CONTIG, NA12877_S1_BAM_FILENAME, 
+        NA12877_S1_EXPECTED_WITH_UNMAPPED, true);
   }
 
   private void testCloudBase(String outputFilename, String contig, String bamFilename, long expectedCount) throws Exception {


### PR DESCRIPTION
@davidadamsphd I packaged reading options together (unmapped reads & stringency).
See if this looks ok, if so - I will also add cmd line param to CountReads pipeline options.
With this CountReads example gets 45142 reads.