### PR TITLE
Configure Travis CI to check java8.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: java
 
+jdk:
+  - oraclejdk8
+  - oraclejdk7
+  - openjdk7
+
 script: mvn test javadoc:javadoc
 
 after_success:

--- a/src/main/java/com/google/cloud/genomics/dataflow/functions/JoinNonVariantSegmentsWithVariants.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/functions/JoinNonVariantSegmentsWithVariants.java
@@ -65,9 +65,10 @@ public class JoinNonVariantSegmentsWithVariants {
    * 
    * All variant fields will be returned.
    * 
-   * @param input
-   * @param auth
-   * @return
+   * @param input PCollection of SearchVariantsRequests to process.
+   * @param auth Auth class containing credentials.
+   * @return PCollection of variant-only Variant objects with calls from non-variant-segments
+   *     merged into the variants with which they overlap.
    */
   public static PCollection<Variant> joinVariantsTransform(
       PCollection<SearchVariantsRequest> input, GenomicsFactory.OfflineAuth auth) {
@@ -79,10 +80,11 @@ public class JoinNonVariantSegmentsWithVariants {
    * consider not only calls that have the variant but also those that match the reference at that
    * variant position.
    * 
-   * @param input
-   * @param auth
+   * @param input PCollection of SearchVariantsRequests to process.
+   * @param auth Auth class containing credentials.
    * @param fields Fields to be returned by the partial response.
-   * @return
+   * @return PCollection of variant-only Variant objects with calls from non-variant-segments
+   *     merged into the variants with which they overlap.
    */
   public static PCollection<Variant> joinVariantsTransform(
       PCollection<SearchVariantsRequest> input, GenomicsFactory.OfflineAuth auth, String fields) {

--- a/src/main/java/com/google/cloud/genomics/dataflow/pipelines/CalculateCoverage.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/pipelines/CalculateCoverage.java
@@ -62,7 +62,7 @@ import java.util.logging.Logger;
  *
  * For each "bucket" in the given input references, this computes the average coverage (rounded to
  * six decimal places) across the bucket that 10%, 20%, 30%, etc. of the input ReadGroupsSets have
- * for each mapping quality of the reads (<10:Low(L), 10-29:Medium(M), >=30:High(H)) as well as
+ * for each mapping quality of the reads (&lt;10:Low(L), 10-29:Medium(M), &gt;=30:High(H)) as well as
  * these same percentiles of ReadGroupSets for all reads regardless of mapping quality (Mapping
  * quality All(A)).
  *

--- a/src/main/java/com/google/cloud/genomics/dataflow/utils/VariantUtils.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/utils/VariantUtils.java
@@ -79,7 +79,7 @@ public class VariantUtils {
   /**
    * Determine whether the variant is a non-variant segment (a.k.a. non-variant block record).
    * 
-   * For data processed by GATK the value of ALT is "<NON_REF>". See
+   * For data processed by GATK the value of ALT is "&lt;NON_REF&gt;". See
    * https://www.broadinstitute.org/gatk/guide/article?id=4017 for more detail.
    */
   public static final Predicate<Variant> IS_NON_VARIANT_SEGMENT_WITH_GATK_ALT = Predicates.and(


### PR DESCRIPTION
Fixes https://github.com/googlegenomics/dataflow-java/issues/109 

It was just the more strict HTML validation in the java8 javadoc lint check that became an error instead of a warning and broke the release.