### PR TITLE
Bump DataflowSDK version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
     <dependency>
       <groupId>com.google.cloud.dataflow</groupId>
       <artifactId>google-cloud-dataflow-java-sdk-all</artifactId>
-      <version>0.4.150710</version>
+      <version>0.4.150727</version>
     </dependency>
 
     <!-- Google client dependencies -->

--- a/src/main/java/com/google/cloud/genomics/dataflow/utils/GCSHelper.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/utils/GCSHelper.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.google.cloud.genomics.dataflow.utils;
 
 import static com.google.api.services.storage.StorageScopes.DEVSTORAGE_READ_ONLY;

--- a/src/main/java/com/google/cloud/genomics/dataflow/utils/GenomicsOptions.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/utils/GenomicsOptions.java
@@ -16,9 +16,9 @@ package com.google.cloud.genomics.dataflow.utils;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 
-import com.google.cloud.dataflow.sdk.options.DataflowPipelineOptions;
 import com.google.cloud.dataflow.sdk.options.Default;
 import com.google.cloud.dataflow.sdk.options.Description;
+import com.google.cloud.dataflow.sdk.options.GcsOptions;
 import com.google.cloud.genomics.utils.GenomicsFactory;
 import com.google.cloud.genomics.utils.GenomicsFactory.Builder;
 
@@ -28,7 +28,7 @@ import com.google.cloud.genomics.utils.GenomicsFactory.Builder;
  *  Note: All methods defined in this class will be called during command line parsing unless it is
  * annotated with a @JsonIgnore annotation.
  */
-public interface GenomicsOptions extends DataflowPipelineOptions {
+public interface GenomicsOptions extends GcsOptions {
 
   public static class Methods {
 

--- a/src/test/java/com/google/cloud/dataflow/coders/GenericJsonCoderTest.java
+++ b/src/test/java/com/google/cloud/dataflow/coders/GenericJsonCoderTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.google.cloud.dataflow.coders;
 
 import static org.junit.Assert.assertTrue;

--- a/src/test/java/com/google/cloud/genomics/dataflow/functions/AlleleSimilarityCalculatorTest.java
+++ b/src/test/java/com/google/cloud/genomics/dataflow/functions/AlleleSimilarityCalculatorTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.google.cloud.genomics.dataflow.functions;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/com/google/cloud/genomics/dataflow/pipelines/CountReadsITCase.java
+++ b/src/test/java/com/google/cloud/genomics/dataflow/pipelines/CountReadsITCase.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.google.cloud.genomics.dataflow.pipelines;
 
 import com.google.api.services.storage.Storage;

--- a/src/test/java/com/google/cloud/genomics/dataflow/readers/bam/BAMIOITCase.java
+++ b/src/test/java/com/google/cloud/genomics/dataflow/readers/bam/BAMIOITCase.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.google.cloud.genomics.dataflow.readers.bam;
 
 import com.google.api.services.genomics.model.Read;

--- a/src/test/java/com/google/cloud/genomics/dataflow/readers/bam/BAMShardTest.java
+++ b/src/test/java/com/google/cloud/genomics/dataflow/readers/bam/BAMShardTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.google.cloud.genomics.dataflow.readers.bam;
 
 import org.junit.runner.RunWith;

--- a/src/test/java/com/google/cloud/genomics/dataflow/readers/bam/ShardingPolicyTest.java
+++ b/src/test/java/com/google/cloud/genomics/dataflow/readers/bam/ShardingPolicyTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.google.cloud.genomics.dataflow.readers.bam;
 
 import org.junit.runner.RunWith;

--- a/src/test/java/com/google/cloud/genomics/dataflow/utils/AnnotationUtilsTest.java
+++ b/src/test/java/com/google/cloud/genomics/dataflow/utils/AnnotationUtilsTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.google.cloud.genomics.dataflow.utils;
 
 import static org.junit.Assert.assertEquals;

--- a/src/test/java/com/google/cloud/genomics/dataflow/utils/GCSHelperITCase.java
+++ b/src/test/java/com/google/cloud/genomics/dataflow/utils/GCSHelperITCase.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.google.cloud.genomics.dataflow.utils;
 
 

--- a/src/test/java/com/google/cloud/genomics/dataflow/utils/PairGeneratorTest.java
+++ b/src/test/java/com/google/cloud/genomics/dataflow/utils/PairGeneratorTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2014 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package com.google.cloud.genomics.dataflow.utils;
 
 import static org.junit.Assert.assertEquals;


### PR DESCRIPTION
Switched from DataflowPipelineOptions to smaller surface GcsOptions, now that options such as `--stagingLocation` are mandatory for DataflowPipelineOptions but not relevant when running locally.  The extra validation does kick in when `--runner=DataflowPipelineRunner` is added to the command line.

Tested via `mvn verify`.