### PR TITLE
Shard boundary semantics now supported for gRPC.

### DIFF
--- a/src/main/java/com/google/cloud/genomics/dataflow/functions/JoinNonVariantSegmentsWithVariants.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/functions/JoinNonVariantSegmentsWithVariants.java
@@ -33,7 +33,7 @@ import com.google.cloud.genomics.dataflow.readers.VariantReader;
 import com.google.cloud.genomics.dataflow.utils.GenomicsDatasetOptions;
 import com.google.cloud.genomics.dataflow.utils.VariantUtils;
 import com.google.cloud.genomics.utils.GenomicsFactory;
-import com.google.cloud.genomics.utils.Paginator.ShardBoundary;
+import com.google.cloud.genomics.utils.ShardBoundary;
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Ordering;
@@ -103,7 +103,7 @@ public class JoinNonVariantSegmentsWithVariants {
     return input
         .apply(
             ParDo.named(VariantReader.class.getSimpleName()).of(
-                new VariantReader(auth, ShardBoundary.STRICT, fields)))
+                new VariantReader(auth, ShardBoundary.Requirement.STRICT, fields)))
         .apply(ParDo.of(new JoinNonVariantSegmentsWithVariants.BinVariants()))
         // TODO check that windowing function is not splitting these groups
         .apply(GroupByKey.<KV<String, Long>, Variant>create())

--- a/src/main/java/com/google/cloud/genomics/dataflow/pipelines/AnnotateVariants.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/pipelines/AnnotateVariants.java
@@ -50,7 +50,7 @@ import com.google.cloud.genomics.dataflow.utils.GenomicsOptions;
 import com.google.cloud.genomics.dataflow.utils.VariantUtils;
 import com.google.cloud.genomics.utils.GenomicsFactory;
 import com.google.cloud.genomics.utils.Paginator;
-import com.google.cloud.genomics.utils.Paginator.ShardBoundary;
+import com.google.cloud.genomics.utils.ShardBoundary;
 import com.google.cloud.genomics.utils.ShardUtils;
 import com.google.common.base.Joiner;
 import com.google.common.base.Stopwatch;
@@ -109,7 +109,7 @@ public final class AnnotateVariants extends DoFn<SearchVariantsRequest, KV<Strin
     SearchVariantsRequest request = c.element();
     LOG.info("processing contig " + request);
     Iterable<Variant> varIter = FluentIterable
-        .from(Paginator.Variants.create(genomics, ShardBoundary.STRICT).search(
+        .from(Paginator.Variants.create(genomics, ShardBoundary.Requirement.STRICT).search(
             request
               // TODO: Variants-only retrieval is not well support currently. For now
               // we parameterize by CallSet for performance.
@@ -176,7 +176,7 @@ public final class AnnotateVariants extends DoFn<SearchVariantsRequest, KV<Strin
     Stopwatch stopwatch = Stopwatch.createStarted();
     ListMultimap<Range<Long>, Annotation> annotationMap = ArrayListMultimap.create();
     Iterable<Annotation> annotationIter =
-        Paginator.Annotations.create(genomics, ShardBoundary.OVERLAPS).search(
+        Paginator.Annotations.create(genomics, ShardBoundary.Requirement.OVERLAPS).search(
             new SearchAnnotationsRequest()
               .setAnnotationSetIds(variantAnnotationSetIds)
               .setRange(new QueryRange()
@@ -200,7 +200,7 @@ public final class AnnotateVariants extends DoFn<SearchVariantsRequest, KV<Strin
     Stopwatch stopwatch = Stopwatch.createStarted();
     IntervalTree<Annotation> transcripts = new IntervalTree<>();
     Iterable<Annotation> transcriptIter =
-        Paginator.Annotations.create(genomics, ShardBoundary.OVERLAPS).search(
+        Paginator.Annotations.create(genomics, ShardBoundary.Requirement.OVERLAPS).search(
             new SearchAnnotationsRequest()
               .setAnnotationSetIds(transcriptSetIds)
               .setRange(new QueryRange()

--- a/src/main/java/com/google/cloud/genomics/dataflow/pipelines/CalculateCoverage.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/pipelines/CalculateCoverage.java
@@ -47,6 +47,7 @@ import com.google.cloud.genomics.utils.Contig;
 import com.google.cloud.genomics.utils.GenomicsFactory;
 import com.google.cloud.genomics.utils.GenomicsUtils;
 import com.google.cloud.genomics.utils.RetryPolicy;
+import com.google.cloud.genomics.utils.ShardBoundary;
 import com.google.cloud.genomics.utils.ShardUtils;
 import com.google.common.collect.Lists;
 import com.google.genomics.v1.CigarUnit;
@@ -496,6 +497,6 @@ public class CalculateCoverage {
         ShardUtils.getReadRequests(rgsIds) :
           ShardUtils.getReadRequests(rgsIds, options.getReferences(), options.getBasesPerShard());
     PCollection<StreamReadsRequest> readRequests = p.begin().apply(Create.of(requests));
-    return readRequests.apply(new ReadStreamer(auth));
+    return readRequests.apply(new ReadStreamer(auth, ShardBoundary.Requirement.OVERLAPS, null));
   }
 }

--- a/src/main/java/com/google/cloud/genomics/dataflow/pipelines/CountReads.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/pipelines/CountReads.java
@@ -47,11 +47,9 @@ import com.google.cloud.genomics.dataflow.utils.GenomicsDatasetOptions;
 import com.google.cloud.genomics.dataflow.utils.GenomicsOptions;
 import com.google.cloud.genomics.utils.Contig;
 import com.google.cloud.genomics.utils.GenomicsFactory;
-import com.google.cloud.genomics.utils.Paginator;
+import com.google.cloud.genomics.utils.ShardBoundary;
 import com.google.cloud.genomics.utils.ShardUtils;
-import com.google.common.base.Function;
 import com.google.common.base.Strings;
-import com.google.common.collect.FluentIterable;
 
 /**
  * Simple read counting pipeline, intended as an example for reading data from
@@ -174,7 +172,7 @@ public class CountReads {
     PCollection<Read> reads =
         readRequests.apply(
             ParDo.of(
-                new ReadReader(auth, Paginator.ShardBoundary.STRICT))
+                new ReadReader(auth, ShardBoundary.Requirement.STRICT))
                 .named(ReadReader.class.getSimpleName()));
     return reads;
   }

--- a/src/main/java/com/google/cloud/genomics/dataflow/pipelines/IdentityByState.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/pipelines/IdentityByState.java
@@ -38,7 +38,7 @@ import com.google.cloud.genomics.dataflow.utils.GenomicsDatasetOptions;
 import com.google.cloud.genomics.dataflow.utils.GenomicsOptions;
 import com.google.cloud.genomics.dataflow.utils.IdentityByStateOptions;
 import com.google.cloud.genomics.utils.GenomicsFactory;
-import com.google.cloud.genomics.utils.Paginator.ShardBoundary;
+import com.google.cloud.genomics.utils.ShardBoundary;
 import com.google.cloud.genomics.utils.ShardUtils;
 
 /**
@@ -79,7 +79,7 @@ public class IdentityByState {
         ? JoinNonVariantSegmentsWithVariants.joinVariantsTransform(input, auth,
             JoinNonVariantSegmentsWithVariants.VARIANT_JOIN_FIELDS) : input.apply(ParDo.named(
             VariantReader.class.getSimpleName()).of(
-            new VariantReader(auth, ShardBoundary.STRICT, VARIANT_FIELDS)));
+            new VariantReader(auth, ShardBoundary.Requirement.STRICT, VARIANT_FIELDS)));
 
     variants
         .apply(

--- a/src/main/java/com/google/cloud/genomics/dataflow/pipelines/TransmissionProbability.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/pipelines/TransmissionProbability.java
@@ -15,6 +15,10 @@
  */
 package com.google.cloud.genomics.dataflow.pipelines;
 
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.List;
+
 import com.google.api.services.genomics.model.SearchVariantsRequest;
 import com.google.cloud.dataflow.sdk.Pipeline;
 import com.google.cloud.dataflow.sdk.io.TextIO;
@@ -32,13 +36,8 @@ import com.google.cloud.genomics.dataflow.utils.DataflowWorkarounds;
 import com.google.cloud.genomics.dataflow.utils.GenomicsDatasetOptions;
 import com.google.cloud.genomics.dataflow.utils.GenomicsOptions;
 import com.google.cloud.genomics.utils.GenomicsFactory;
-import com.google.cloud.genomics.utils.Paginator.ShardBoundary;
+import com.google.cloud.genomics.utils.ShardBoundary;
 import com.google.cloud.genomics.utils.ShardUtils;
-import com.google.cloud.genomics.utils.ShardUtils.SexChromosomeFilter;
-
-import java.io.IOException;
-import java.security.GeneralSecurityException;
-import java.util.List;
 
 /**
  * A pipeline that calculates the transmission probability of each allele in parents.
@@ -75,7 +74,7 @@ public class TransmissionProbability {
     p.begin()
         .apply(Create.of(requests))
         .apply(ParDo.named("VariantReader")
-            .of(new VariantReader(auth, ShardBoundary.STRICT, VARIANT_FIELDS)))
+            .of(new VariantReader(auth, ShardBoundary.Requirement.STRICT, VARIANT_FIELDS)))
         .apply(ParDo.named("ExtractFamilyVariantStatus")
             .of(new ExtractAlleleTransmissionStatus()))
         .apply(GroupByKey.<Allele, Boolean>create())

--- a/src/main/java/com/google/cloud/genomics/dataflow/readers/ReadReader.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/readers/ReadReader.java
@@ -25,7 +25,7 @@ import com.google.api.services.genomics.model.SearchReadsRequest;
 import com.google.cloud.genomics.dataflow.utils.GenomicsOptions;
 import com.google.cloud.genomics.utils.GenomicsFactory;
 import com.google.cloud.genomics.utils.Paginator;
-import com.google.cloud.genomics.utils.Paginator.ShardBoundary;
+import com.google.cloud.genomics.utils.ShardBoundary;
 
 /**
  * ReadReader is a DoFn that takes SearchReadsRequests, submits them
@@ -35,7 +35,7 @@ import com.google.cloud.genomics.utils.Paginator.ShardBoundary;
  */
 public class ReadReader extends GenomicsApiReader<SearchReadsRequest, Read> {
   private static final Logger LOG = Logger.getLogger(ReadReader.class.getName());
-  private final ShardBoundary shardBoundary;
+  private final ShardBoundary.Requirement shardBoundary;
 
   /**
    * Create a ReadReader using a auth and fields parameter. All fields not specified under 
@@ -44,7 +44,7 @@ public class ReadReader extends GenomicsApiReader<SearchReadsRequest, Read> {
    * @param auth Auth class containing credentials.
    * @param readFields Fields to return in responses.
    */
-  public ReadReader(GenomicsFactory.OfflineAuth auth, ShardBoundary shardBoundary, String readFields) {
+  public ReadReader(GenomicsFactory.OfflineAuth auth, ShardBoundary.Requirement shardBoundary, String readFields) {
     super(auth, readFields);
     this.shardBoundary = shardBoundary;
   }
@@ -53,7 +53,7 @@ public class ReadReader extends GenomicsApiReader<SearchReadsRequest, Read> {
    * Create a ReadReader with no fields parameter, all information will be returned.
    * @param auth Auth class containing credentials.
    */
-  public ReadReader(GenomicsFactory.OfflineAuth auth, ShardBoundary shardBoundary) {
+  public ReadReader(GenomicsFactory.OfflineAuth auth, ShardBoundary.Requirement shardBoundary) {
     this(auth, shardBoundary, null);
   }
 

--- a/src/main/java/com/google/cloud/genomics/dataflow/readers/VariantReader.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/readers/VariantReader.java
@@ -24,11 +24,11 @@ import com.google.api.services.genomics.model.Variant;
 import com.google.cloud.genomics.dataflow.utils.GenomicsDatasetOptions;
 import com.google.cloud.genomics.utils.GenomicsFactory;
 import com.google.cloud.genomics.utils.Paginator;
-import com.google.cloud.genomics.utils.Paginator.ShardBoundary;
+import com.google.cloud.genomics.utils.ShardBoundary;
 
 public class VariantReader extends GenomicsApiReader<SearchVariantsRequest, Variant> {
   private static final Logger LOG = Logger.getLogger(VariantReader.class.getName());
-  private final ShardBoundary shardBoundary;
+  private final ShardBoundary.Requirement shardBoundary;
 
   /**
    * Create a VariantReader using a auth and fields parameter. All fields not specified under 
@@ -37,7 +37,7 @@ public class VariantReader extends GenomicsApiReader<SearchVariantsRequest, Vari
    * @param auth Auth class containing credentials.
    * @param variantFields Fields to return in responses.
    */
-  public VariantReader(GenomicsFactory.OfflineAuth auth, ShardBoundary shardBoundary, String variantFields) {
+  public VariantReader(GenomicsFactory.OfflineAuth auth, ShardBoundary.Requirement shardBoundary, String variantFields) {
     super(auth, variantFields);
     this.shardBoundary = shardBoundary;
   }
@@ -46,7 +46,7 @@ public class VariantReader extends GenomicsApiReader<SearchVariantsRequest, Vari
    * Create a VariantReader with no fields parameter, all information will be returned.
    * @param auth Auth class containing credentials.
    */
-  public VariantReader(GenomicsFactory.OfflineAuth auth, ShardBoundary shardBoundary) {
+  public VariantReader(GenomicsFactory.OfflineAuth auth, ShardBoundary.Requirement shardBoundary) {
     this(auth, shardBoundary, null);
   }
 

--- a/src/test/java/com/google/cloud/genomics/dataflow/pipelines/VariantSimilarityITCase.java
+++ b/src/test/java/com/google/cloud/genomics/dataflow/pipelines/VariantSimilarityITCase.java
@@ -101,7 +101,7 @@ public class VariantSimilarityITCase {
         "--references=" + helper.PLATINUM_GENOMES_BRCA1_REFERENCES,
         "--datasetId=" + helper.PLATINUM_GENOMES_DATASET,
         "--output=" + outputPrefix,
-        "--useStreaming=false"
+        "--useGrpc=false"
         };
     testBase(ARGS);
   }
@@ -116,7 +116,7 @@ public class VariantSimilarityITCase {
         "--project=" + helper.getTestProject(),
         "--runner=BlockingDataflowPipelineRunner",
         "--stagingLocation=" + helper.getTestStagingGcsFolder(),
-        "--useStreaming=false"
+        "--useGrpc=false"
         };
     testBase(ARGS);
   }
@@ -131,7 +131,7 @@ public class VariantSimilarityITCase {
         "--references=" + helper.PLATINUM_GENOMES_BRCA1_REFERENCES,
         "--datasetId=" + helper.PLATINUM_GENOMES_DATASET,
         "--output=" + outputPrefix,
-        "--useStreaming=true"
+        "--useGrpc=true"
         };
     testBase(ARGS);
   }
@@ -146,7 +146,7 @@ public class VariantSimilarityITCase {
         "--project=" + helper.getTestProject(),
         "--runner=BlockingDataflowPipelineRunner",
         "--stagingLocation=" + helper.getTestStagingGcsFolder(),
-        "--useStreaming=true"
+        "--useGrpc=true"
         };
     testBase(ARGS);
   }


### PR DESCRIPTION
Goes along with https://github.com/googlegenomics/utils-java/pull/54

Tested this via:
* utils-java/refactor-part1: mvn install
* dataflow-java/refactor-redo: mvn verify