### PR TITLE
stop registerGenomicsCoders from filling up the screen with log messages

### DIFF
--- a/src/main/java/com/google/cloud/genomics/dataflow/utils/DataflowWorkarounds.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/utils/DataflowWorkarounds.java
@@ -69,7 +69,7 @@ public class DataflowWorkarounds {
    */
   @SuppressWarnings({"unchecked", "rawtypes"})
   public static void registerGenomicsCoders(Pipeline p) {
-    LOG.info("Registering coders for genomics classes");
+    LOG.fine("Registering coders for genomics classes");
     
     List<ClassLoader> classLoadersList = new LinkedList<ClassLoader>();
     classLoadersList.add(ClasspathHelper.contextClassLoader());
@@ -94,7 +94,7 @@ public class DataflowWorkarounds {
             FilterBuilder.prefix("com.google.api.services.genomics.model"))));
     
     for (Class clazz : reflections.getSubTypesOf(GenericJson.class)) {
-      LOG.info("Registering coder for " + clazz.getSimpleName());
+      LOG.finer("Registering coder for " + clazz.getSimpleName());
       DataflowWorkarounds.registerCoder(p, clazz, GenericJsonCoder.of(clazz));
     }
   }


### PR DESCRIPTION
registerGenomicsCoders prints many lines (one per registered class), and those messages are only useful when debugging specific coder-related bugs. These messages are printed for everyone who uses our library, and it makes their own logging less useful. I propose to mark those messages as "fine" and "finer".