### PR TITLE
Revert back to string indices for variant similarity.

### DIFF
--- a/src/test/java/com/google/cloud/genomics/dataflow/functions/ExtractSimilarCallsetsTest.java
+++ b/src/test/java/com/google/cloud/genomics/dataflow/functions/ExtractSimilarCallsetsTest.java
@@ -37,20 +37,9 @@ import com.google.genomics.v1.VariantCall;
 @RunWith(JUnit4.class)
 public class ExtractSimilarCallsetsTest {
   
-  BiMap<String, Integer> dataIndices;
-  
-  @Before
-  public void setUp() {
-    dataIndices = HashBiMap.create();
-    dataIndices.put("ref", dataIndices.size());
-    dataIndices.put("alt1", dataIndices.size());
-    dataIndices.put("alt2", dataIndices.size());
-    dataIndices.put("alt3", dataIndices.size());
-  }
-
   @Test
   public void testGetSamplesWithVariant() throws Exception {
-    ExtractSimilarCallsets.v1 doFn = new ExtractSimilarCallsets.v1(dataIndices);
+    ExtractSimilarCallsets.v1 doFn = new ExtractSimilarCallsets.v1();
     
     Variant variant = Variant.newBuilder().build();
     assertEquals(Collections.emptyList(), doFn.getSamplesWithVariant(variant));
@@ -61,18 +50,18 @@ public class ExtractSimilarCallsetsTest {
 
     VariantCall alt1 = DataUtils.makeVariantCall("alt1", 1, 0);
     variant = Variant.newBuilder().addCalls(ref).addCalls(alt1).build();
-    assertEquals(Collections.singletonList(1), doFn.getSamplesWithVariant(variant));
+    assertEquals(Collections.singletonList("alt1"), doFn.getSamplesWithVariant(variant));
 
     VariantCall alt2 = DataUtils.makeVariantCall("alt2", 0, 1);
     VariantCall alt3 = DataUtils.makeVariantCall("alt3", 1, 1);
     variant = Variant.newBuilder().addCalls(ref)
         .addCalls(alt1).addCalls(alt2).addCalls(alt3).build();
-    assertEquals(Arrays.asList(1, 2, 3), doFn.getSamplesWithVariant(variant));
+    assertEquals(Arrays.asList("alt1", "alt2", "alt3"), doFn.getSamplesWithVariant(variant));
   }
 
   @Test
   public void testGetSamplesWithVariantv1beta2() throws Exception {
-    ExtractSimilarCallsets.v1beta2 doFn = new ExtractSimilarCallsets.v1beta2(dataIndices);
+    ExtractSimilarCallsets.v1beta2 doFn = new ExtractSimilarCallsets.v1beta2();
 
     com.google.api.services.genomics.model.Variant variant = new com.google.api.services.genomics.model.Variant();
     List<Call> calls = new ArrayList<Call>();
@@ -84,10 +73,10 @@ public class ExtractSimilarCallsetsTest {
     assertEquals(Collections.emptyList(), doFn.getSamplesWithVariant(variant));
 
     calls.add(DataUtils.makeCall("alt1", 1, 0));
-    assertEquals(Collections.singletonList(1), doFn.getSamplesWithVariant(variant));
+    assertEquals(Collections.singletonList("alt1"), doFn.getSamplesWithVariant(variant));
 
     calls.add(DataUtils.makeCall("alt2", 0, 1));
     calls.add(DataUtils.makeCall("alt3", 1, 1));
-    assertEquals(Arrays.asList(1, 2, 3), doFn.getSamplesWithVariant(variant));
+    assertEquals(Arrays.asList("alt1", "alt2", "alt3"), doFn.getSamplesWithVariant(variant));
   }  
 }


### PR DESCRIPTION
This commit reverses the negative impact on performance of commit 98cf2c2650322e08d1cb836ec72eb52de6f01b24 while still maintaining a stable sort on the final results.