### PR TITLE
Fix an off-by-one error in the bam Sharder and bam Reader.

### DIFF
--- a/src/main/java/com/google/cloud/genomics/dataflow/readers/bam/Reader.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/readers/bam/Reader.java
@@ -203,7 +203,7 @@ public class Reader {
     SamReader samReader = BAMIO.openBAM(storageClient, storagePath, options.getStringency());
     SAMRecordIterator iterator =  samReader.queryOverlapping(contig.referenceName, 
         (int) contig.start + 1,
-        (int) contig.end + 1);
+        (int) contig.end);
     List<Read> reads = new ArrayList<Read>(); 
     
     int recordsBeforeStart = 0;

--- a/src/main/java/com/google/cloud/genomics/dataflow/readers/bam/Sharder.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/readers/bam/Sharder.java
@@ -97,7 +97,7 @@ public class Sharder {
           @Override
           @Nullable
           public Contig apply(@Nullable Contig arg0) {
-            return new Contig(arg0.referenceName, arg0.start + 1, arg0.end + 1);
+            return new Contig(arg0.referenceName, arg0.start + 1, arg0.end);
           }
         });
     this.output = output;


### PR DESCRIPTION
"mvn verify" now passes.