### PR TITLE
Switch VerifyBamId to v1 Position objects.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
     <dependency>
       <groupId>com.google.cloud.dataflow</groupId>
       <artifactId>google-cloud-dataflow-java-sdk-all</artifactId>
-      <version>1.2.1</version>
+      <version>1.3.0</version>
     </dependency>
 
     <!-- Google client dependencies -->

--- a/src/main/java/com/google/cloud/genomics/dataflow/functions/LikelihoodFn.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/functions/LikelihoodFn.java
@@ -15,12 +15,12 @@
  */
 package com.google.cloud.genomics.dataflow.functions;
 
-import com.google.api.services.genomics.model.Position;
 import com.google.cloud.genomics.dataflow.model.ReadCounts;
 import com.google.cloud.genomics.dataflow.model.ReadQualityCount;
 import com.google.cloud.genomics.dataflow.model.ReadQualityCount.Base;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.genomics.v1.Position;
 
 import org.apache.commons.math3.analysis.UnivariateFunction;
 

--- a/src/main/java/com/google/cloud/genomics/dataflow/model/ReadBaseWithReference.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/model/ReadBaseWithReference.java
@@ -15,8 +15,9 @@
  */
 package com.google.cloud.genomics.dataflow.model;
 
-import com.google.api.services.genomics.model.Position;
 import java.util.Objects;
+
+import com.google.genomics.v1.Position;
 
 /**
  * Data on a single base in a read connected with it reference data.
@@ -30,7 +31,7 @@ public class ReadBaseWithReference {
   public ReadBaseWithReference() {
     this.rbq = new ReadBaseQuality();
     this.refBase = "";
-    this.refPosition = new Position().setPosition(0L).setReferenceName("");
+    this.refPosition = Position.newBuilder().setPosition(0L).setReferenceName("").build();
   }
 
   public ReadBaseWithReference(ReadBaseQuality rbq, String refBase, Position refPosition) {

--- a/src/main/java/com/google/cloud/genomics/dataflow/pipelines/VariantSimilarity.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/pipelines/VariantSimilarity.java
@@ -22,8 +22,6 @@ import java.util.List;
 
 import com.google.api.services.genomics.model.SearchVariantsRequest;
 import com.google.cloud.dataflow.sdk.Pipeline;
-import com.google.cloud.dataflow.sdk.coders.Proto2Coder;
-import com.google.cloud.dataflow.sdk.coders.SerializableCoder;
 import com.google.cloud.dataflow.sdk.options.Default;
 import com.google.cloud.dataflow.sdk.options.Description;
 import com.google.cloud.dataflow.sdk.options.PipelineOptionsFactory;
@@ -46,7 +44,6 @@ import com.google.cloud.genomics.utils.ShardUtils;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
 import com.google.genomics.v1.StreamVariantsRequest;
-import com.google.genomics.v1.Variant;
 
 /**
  * A pipeline that generates similarity data for variants in a dataset.

--- a/src/main/java/com/google/cloud/genomics/dataflow/pipelines/VerifyBamId.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/pipelines/VerifyBamId.java
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.Map;
 
 import com.google.api.client.util.Strings;
-import com.google.api.services.genomics.model.Position;
 import com.google.cloud.dataflow.sdk.Pipeline;
 import com.google.cloud.dataflow.sdk.io.TextIO;
 import com.google.cloud.dataflow.sdk.options.Default;
@@ -67,6 +66,7 @@ import com.google.cloud.genomics.utils.ShardUtils.SexChromosomeFilter;
 import com.google.common.collect.ImmutableMultiset;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multiset;
+import com.google.genomics.v1.Position;
 import com.google.genomics.v1.Read;
 import com.google.genomics.v1.StreamVariantsRequest;
 import com.google.genomics.v1.Variant;
@@ -356,9 +356,10 @@ public class VerifyBamId {
     public void processElement(ProcessContext c) throws Exception {
       ListValue lv = c.element().getInfo().get("AF");
       if (lv != null && lv.getValuesCount() > 0) {
-        Position p = new Position()
+        Position p = Position.newBuilder()
             .setPosition(c.element().getStart())
-            .setReferenceName(c.element().getReferenceName());
+            .setReferenceName(c.element().getReferenceName())
+            .build();
         AlleleFreq af = new AlleleFreq();
         af.setRefFreq(lv.getValues(0).getNumberValue());
         af.setAltBases(c.element().getAlternateBasesList());

--- a/src/main/java/com/google/cloud/genomics/dataflow/utils/ReadFunctions.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/utils/ReadFunctions.java
@@ -19,12 +19,12 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import com.google.api.services.genomics.model.Position;
 import com.google.cloud.dataflow.sdk.transforms.SerializableFunction;
 import com.google.cloud.genomics.dataflow.model.ReadBaseQuality;
 import com.google.cloud.genomics.dataflow.model.ReadBaseWithReference;
 import com.google.common.collect.ImmutableList;
 import com.google.genomics.v1.CigarUnit;
+import com.google.genomics.v1.Position;
 import com.google.genomics.v1.Read;
 
 /**
@@ -84,10 +84,11 @@ public class ReadFunctions {
             if (m.matches()) {
               name = m.group(m.groupCount() - 1);
             }
-            Position refPosition = new Position()
+            Position refPosition = Position.newBuilder()
                 .setReferenceName(name)
                 .setPosition(read.getAlignment().getPosition().getPosition()
-                  + refPosAbsoluteOffset);
+                  + refPosAbsoluteOffset)
+                  .build();
             bases.add(new ReadBaseWithReference(new ReadBaseQuality(
                 readSeq.substring(readOffset, readOffset + 1),
                 readQual.get(readOffset)),

--- a/src/test/java/com/google/cloud/genomics/dataflow/coders/GenericJsonCoderProviderTest.java
+++ b/src/test/java/com/google/cloud/genomics/dataflow/coders/GenericJsonCoderProviderTest.java
@@ -11,10 +11,10 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-import com.google.api.services.genomics.model.Read;
 import com.google.cloud.dataflow.sdk.coders.CannotProvideCoderException;
 import com.google.cloud.dataflow.sdk.coders.Coder;
 import com.google.cloud.dataflow.sdk.coders.CoderRegistry;
+import com.google.cloud.dataflow.sdk.coders.Proto2Coder;
 import com.google.cloud.dataflow.sdk.coders.SerializableCoder;
 
 public class GenericJsonCoderProviderTest {
@@ -36,12 +36,18 @@ public class GenericJsonCoderProviderTest {
 
   @Test
   public void testGenericJsonFallbackCoderProvider() throws Exception {
-    Coder<?> coder = registry.getDefaultCoder(Read.class);
-    assertEquals(coder, GenericJsonCoder.of(Read.class));
+    Coder<?> coder = registry.getDefaultCoder(com.google.api.services.genomics.model.Read.class);
+    assertEquals(coder, GenericJsonCoder.of(com.google.api.services.genomics.model.Read.class));
   }
 
   @Test
-  public void testGenericJsonFallbackCoderProviderFallsback() throws Exception {
+  public void testGenericJsonFallbackCoderProviderFallsbackToProto2Coder() throws Exception {
+    Coder<?> coder = registry.getDefaultCoder(com.google.genomics.v1.Read.class);
+    assertEquals(coder, Proto2Coder.of(com.google.genomics.v1.Read.class));
+  }
+
+  @Test
+  public void testGenericJsonFallbackCoderProviderFallsbackToSerialiableCoder() throws Exception {
     Coder<?> coder = registry.getDefaultCoder(SerializableClass.class);
     assertEquals(coder, SerializableCoder.of(SerializableClass.class));
   }
@@ -53,8 +59,7 @@ public class GenericJsonCoderProviderTest {
         containsString(NotGenericJsonClass.class.getCanonicalName()),
         containsString("No CoderFactory has been registered"),
         containsString("does not have a @DefaultCoder annotation"),
-        containsString("does not implement GenericJson or Serialized")));
+        containsString("does not implement GenericJson, Message, or Serializable")));
     Coder<?> coder = registry.getDefaultCoder(NotGenericJsonClass.class);
   }
 }
-

--- a/src/test/java/com/google/cloud/genomics/dataflow/functions/LikelihoodFnTest.java
+++ b/src/test/java/com/google/cloud/genomics/dataflow/functions/LikelihoodFnTest.java
@@ -15,11 +15,11 @@
  */
 package com.google.cloud.genomics.dataflow.functions;
 
-import com.google.api.services.genomics.model.Position;
 import com.google.cloud.genomics.dataflow.model.ReadCounts;
 import com.google.cloud.genomics.dataflow.model.ReadQualityCount;
 import com.google.cloud.genomics.dataflow.model.ReadQualityCount.Base;
 import com.google.common.collect.ImmutableMap;
+import com.google.genomics.v1.Position;
 
 import junit.framework.TestCase;
 
@@ -43,9 +43,10 @@ public class LikelihoodFnTest extends TestCase {
     final int errPhred = 10;  // P(err) = 0.1
     final double pRef = 0.6;
 
-    Position position1 = new Position()
+    Position position1 = Position.newBuilder()
         .setReferenceName("1")
-        .setPosition(123L);
+        .setPosition(123L)
+        .build();
 
     /*
      * Observe single REF read
@@ -104,9 +105,10 @@ public class LikelihoodFnTest extends TestCase {
 
     // Likelihood for reads at 2 different positions should be product of
     // likelihoods for individual reads
-    Position position2 = new Position()
+    Position position2 = Position.newBuilder()
         .setReferenceName("1")
-        .setPosition(124L);
+        .setPosition(124L)
+        .build();
     countsBuilder = ImmutableMap.builder();
     rc = new ReadCounts();
     rc.setRefFreq(pRef);

--- a/src/test/java/com/google/cloud/genomics/dataflow/pipelines/VerifyBamIdTest.java
+++ b/src/test/java/com/google/cloud/genomics/dataflow/pipelines/VerifyBamIdTest.java
@@ -15,7 +15,6 @@
  */
 package com.google.cloud.genomics.dataflow.pipelines;
 
-import com.google.api.services.genomics.model.Position;
 import com.google.cloud.dataflow.sdk.Pipeline;
 import com.google.cloud.dataflow.sdk.options.PipelineOptionsFactory;
 import com.google.cloud.dataflow.sdk.testing.DataflowAssert;
@@ -43,11 +42,11 @@ import com.google.common.collect.ImmutableList;
 import com.google.genomics.v1.CigarUnit;
 import com.google.genomics.v1.CigarUnit.Operation;
 import com.google.genomics.v1.LinearAlignment;
+import com.google.genomics.v1.Position;
 import com.google.genomics.v1.Read;
 import com.google.genomics.v1.Variant;
 import com.google.protobuf.ListValue;
 import com.google.protobuf.Value;
-
 import com.beust.jcommander.internal.Lists;
 
 import org.hamcrest.CoreMatchers;
@@ -76,9 +75,10 @@ public class VerifyBamIdTest {
         .setAlignedSequence("A")
         .addAlignedQuality(3)
         .build();
-    Assert.assertThat(splitReads.processBatch(r), CoreMatchers.hasItems(KV.of(new Position()
+    Assert.assertThat(splitReads.processBatch(r), CoreMatchers.hasItems(KV.of(Position.newBuilder()
             .setReferenceName("1")
-            .setPosition(123L),
+            .setPosition(123L)
+            .build(),
             new ReadBaseQuality("A", 3))));
     
     // two matched bases -> two SingleReadQuality protos
@@ -94,13 +94,15 @@ public class VerifyBamIdTest {
         .setAlignedSequence("AG")
         .addAllAlignedQuality(ImmutableList.of(3, 4))
         .build();
-    Assert.assertThat(splitReads.processBatch(r), CoreMatchers.hasItems(KV.of(new Position()
+    Assert.assertThat(splitReads.processBatch(r), CoreMatchers.hasItems(KV.of(Position.newBuilder()
             .setReferenceName("1")
-            .setPosition(123L),
+            .setPosition(123L)
+            .build(),
             new ReadBaseQuality("A", 3)),
-        KV.of(new Position()
+        KV.of(Position.newBuilder()
             .setReferenceName("1")
-            .setPosition(124L),
+            .setPosition(124L)
+            .build(),
             new ReadBaseQuality("G", 4))));
     
     // matched bases with different offsets onto the reference
@@ -126,17 +128,20 @@ public class VerifyBamIdTest {
         .setAlignedSequence("ACGT")
         .addAllAlignedQuality(ImmutableList.of(1, 2, 3, 4))
         .build();
-    Assert.assertThat(splitReads.processBatch(r), CoreMatchers.hasItems(KV.of(new Position()
+    Assert.assertThat(splitReads.processBatch(r), CoreMatchers.hasItems(KV.of(Position.newBuilder()
             .setReferenceName("1")
-            .setPosition(123L),
+            .setPosition(123L)
+            .build(),
             new ReadBaseQuality("C", 2)),
-        KV.of(new Position()
+        KV.of(Position.newBuilder()
             .setReferenceName("1")
-            .setPosition(125L),
+            .setPosition(125L)
+            .build(),
             new ReadBaseQuality("G", 3)),
-        KV.of(new Position()
+        KV.of(Position.newBuilder()
             .setReferenceName("1")
-            .setPosition(126L),
+            .setPosition(126L)
+            .build(),
             new ReadBaseQuality("T", 4))));
     
     // matched bases with different offsets onto the reference
@@ -161,17 +166,20 @@ public class VerifyBamIdTest {
         .setAlignedSequence("ACGT")
         .addAllAlignedQuality(ImmutableList.of(1, 2, 3, 4))
         .build();
-    Assert.assertThat(splitReads.processBatch(r), CoreMatchers.hasItems(KV.of(new Position()
+    Assert.assertThat(splitReads.processBatch(r), CoreMatchers.hasItems(KV.of(Position.newBuilder()
             .setReferenceName("1")
-            .setPosition(124L),
+            .setPosition(124L)
+            .build(),
             new ReadBaseQuality("A", 1)),
-        KV.of(new Position()
+        KV.of(Position.newBuilder()
             .setReferenceName("1")
-            .setPosition(125L),
+            .setPosition(125L)
+            .build(),
             new ReadBaseQuality("C", 2)),
-        KV.of(new Position()
+        KV.of(Position.newBuilder()
             .setReferenceName("1")
-            .setPosition(126L),
+            .setPosition(126L)
+            .build(),
             new ReadBaseQuality("T", 4))));
   }
   
@@ -179,16 +187,18 @@ public class VerifyBamIdTest {
   public void testSampleReads() {
     SampleReads sampleReads = new SampleReads(0.5, "");
     Assert.assertTrue(sampleReads.apply(KV.of(
-        new Position()
+        Position.newBuilder()
             .setReferenceName("1")
             .setPosition(125L)
-            .setReverseStrand(false),
+            .setReverseStrand(false)
+            .build(),
         new ReadBaseQuality())));
     Assert.assertFalse(sampleReads.apply(KV.of(
-        new Position()
+        Position.newBuilder()
             .setReferenceName("2")
             .setPosition(124L)
-            .setReverseStrand(false),
+            .setReverseStrand(false)
+            .build(),
         new ReadBaseQuality())));
   }
   
@@ -196,7 +206,10 @@ public class VerifyBamIdTest {
   public void testGetAlleleFreq() {
     DoFnTester<Variant, KV<Position, AlleleFreq>> getAlleleFreq = DoFnTester.of(
         new GetAlleleFreq());
-    Position pos = new Position().setReferenceName("1").setPosition(123L);
+    Position pos = Position.newBuilder()
+        .setReferenceName("1")
+        .setPosition(123L)
+        .build();
     Variant.Builder vBuild = Variant.newBuilder()
         .setReferenceName("1")
         .setStart(123L)
@@ -215,7 +228,10 @@ public class VerifyBamIdTest {
   @Test
   public void testFilterFreq() {
     FilterFreq filterFreq = new FilterFreq(0.01);
-    Position pos = new Position().setReferenceName("1").setPosition(123L);
+    Position pos = Position.newBuilder()
+        .setReferenceName("1")
+        .setPosition(123L)
+        .build();
     AlleleFreq af = new AlleleFreq();
     af.setRefFreq(0.9999);
     Assert.assertFalse(filterFreq.apply(KV.of(pos, af)));
@@ -226,17 +242,20 @@ public class VerifyBamIdTest {
   }
   
   private final Position position1
-    = new Position()
+    = Position.newBuilder()
       .setReferenceName("1")
-      .setPosition(123L);
+      .setPosition(123L)
+      .build();
   private final Position position2
-    = new Position()
+    = Position.newBuilder()
       .setReferenceName("1")
-      .setPosition(124L);
+      .setPosition(124L)
+      .build();
   private final Position position3
-    = new Position()
+    = Position.newBuilder()
       .setReferenceName("1")
-      .setPosition(125L);
+      .setPosition(125L)
+      .build();
 
   private final ImmutableList<KV<Position, AlleleFreq>> refCountList;
   {

--- a/src/test/java/com/google/cloud/genomics/dataflow/utils/ReadFunctionsTest.java
+++ b/src/test/java/com/google/cloud/genomics/dataflow/utils/ReadFunctionsTest.java
@@ -186,9 +186,10 @@ public class ReadFunctionsTest {
                 alignedSeq.substring(i, i + 1),
                 quals.get(qualityOffset)),
             alignedRef.substring(i, i + 1),
-            new com.google.api.services.genomics.model.Position()
+            Position.newBuilder()
             .setReferenceName(chromosome)
-            .setPosition((long) (originalPos + refPositionOffset)));
+            .setPosition((long) (originalPos + refPositionOffset))
+            .build());
         qualityOffset++;
         refPositionOffset++;
         readBaseList.add(sr);

--- a/src/test/java/com/google/cloud/genomics/dataflow/utils/SolverTest.java
+++ b/src/test/java/com/google/cloud/genomics/dataflow/utils/SolverTest.java
@@ -15,12 +15,12 @@
  */
 package com.google.cloud.genomics.dataflow.utils;
 
-import com.google.api.services.genomics.model.Position;
 import com.google.cloud.genomics.dataflow.functions.LikelihoodFn;
 import com.google.cloud.genomics.dataflow.model.ReadCounts;
 import com.google.cloud.genomics.dataflow.model.ReadQualityCount;
 import com.google.cloud.genomics.dataflow.model.ReadQualityCount.Base;
 import com.google.common.collect.ImmutableMap;
+import com.google.genomics.v1.Position;
 
 import junit.framework.TestCase;
 
@@ -79,9 +79,10 @@ public class SolverTest extends TestCase {
   public void testSolverOnKnownLikelihoodCases() {
     int phred = 200;
 
-    Position position1 = new Position()
+    Position position1 = Position.newBuilder()
         .setReferenceName("1")
-        .setPosition(123L);
+        .setPosition(123L)
+        .build();
 
     /*
      * Observe 900 REF reads and 100 NONREF


### PR DESCRIPTION
The VerifyBamId pipeline requires a deterministic coder due to the CoGroupByKey, hence the change to  Proto2Coder which is deterministic and supports the v1 proto3 objects.

Note that this pipeline no longer requires GenericJsonCoder, but it does need Proto2Coder and SerializableCoder, so I just added more fallback logic to GenericJsonCoder so that we can just use it for all pipelines for the near term to keep the coder stuff simple.