### PR TITLE
Bump dataflow and grpc (via utils-java) dependencies.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
     <dependency>
       <groupId>com.google.cloud.dataflow</groupId>
       <artifactId>google-cloud-dataflow-java-sdk-all</artifactId>
-      <version>1.3.0</version>
+      <version>1.4.0</version>
     </dependency>
 
     <!-- Google client dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
     <dependency>
       <groupId>com.google.cloud.genomics</groupId>
       <artifactId>google-genomics-utils</artifactId>
-      <version>v1beta2-0.38</version>
+      <version>v1beta2-0.39</version>
       <exclusions>
         <!-- Exclude an old version of guava which is being pulled
              in by a transitive dependency google-api-client 1.19.0 -->


### PR DESCRIPTION
Fixes https://github.com/googlegenomics/dataflow-java/issues/163

Manually testing via `mvn verify` right now.  Travis CI will turn green when utils-java makes it onto maven central.

Will wait to merge till both those are complete.