### PR TITLE
Fix parallelism for ReadGroupStreamer.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -207,7 +207,7 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>3.0.0-beta-1</version>
+      <version>3.0.0-beta-2</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
This was tested manually to ensure that the number of active Dataflow tasks was larger than the number of read group sets.