### PR TITLE
Bump utils-java.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
     <dependency>
       <groupId>com.google.cloud.genomics</groupId>
       <artifactId>google-genomics-utils</artifactId>
-      <version>v1beta2-0.40</version>
+      <version>v1beta2-0.41</version>
       <exclusions>
         <!-- Exclude an old version of guava which is being pulled
              in by a transitive dependency google-api-client 1.19.0 -->


### PR DESCRIPTION
Doing this a second time because the prior release of utils-java did not actually include the grpc-java version bump to 0.13.0.