### PR TITLE
Bug fixes for pipelines using partial responses.

### DIFF
--- a/src/main/java/com/google/cloud/genomics/dataflow/pipelines/AnnotateVariants.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/pipelines/AnnotateVariants.java
@@ -124,6 +124,8 @@ public final class AnnotateVariants extends DoFn<StreamVariantsRequest, KV<Strin
 
   private static final Logger LOG = Logger.getLogger(AnnotateVariants.class.getName());
   private static final int VARIANTS_PAGE_SIZE = 5000;
+  // Tip: Use the API explorer to test which fields to include in partial responses.
+  // https://developers.google.com/apis-explorer/#p/genomics/v1/genomics.variants.stream?fields=variants(alternateBases%252Ccalls(callSetName%252Cgenotype)%252CreferenceBases)&_h=3&resource=%257B%250A++%2522variantSetId%2522%253A+%25223049512673186936334%2522%252C%250A++%2522referenceName%2522%253A+%2522chr17%2522%252C%250A++%2522start%2522%253A+%252241196311%2522%252C%250A++%2522end%2522%253A+%252241196312%2522%252C%250A++%2522callSetIds%2522%253A+%250A++%255B%25223049512673186936334-0%2522%250A++%255D%250A%257D&
   private static final String VARIANT_FIELDS
       = "variants(id,referenceName,start,end,alternateBases,referenceBases)";
 

--- a/src/main/java/com/google/cloud/genomics/dataflow/pipelines/CalculateCoverage.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/pipelines/CalculateCoverage.java
@@ -141,6 +141,8 @@ public class CalculateCoverage {
     void setAnnotationSetName(String name);
   }
 
+  // Tip: Use the API explorer to test which fields to include in partial responses.
+  // https://developers.google.com/apis-explorer/#p/genomics/v1/genomics.reads.stream?fields=alignments(alignedSequence%252Cid)&_h=2&resource=%257B%250A++%2522readGroupSetId%2522%253A+%2522CMvnhpKTFhD3he72j4KZuyc%2522%252C%250A++%2522referenceName%2522%253A+%2522chr17%2522%252C%250A++%2522start%2522%253A+%252241196311%2522%252C%250A++%2522end%2522%253A+%252241196312%2522%250A%257D&
   private static final String READ_FIELDS = "alignments(alignment,readGroupSetId)";
   private static Options options;
   private static Pipeline p;

--- a/src/main/java/com/google/cloud/genomics/dataflow/pipelines/CountReads.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/pipelines/CountReads.java
@@ -95,7 +95,7 @@ public class CountReads {
 
   }
 
-  private static final String READ_FIELDS = "alignments(id)";
+  private static final String READ_FIELDS = "alignments(alignment,id)";
   private static final Logger LOG = Logger.getLogger(CountReads.class.getName());
   private static Pipeline p;
   private static Options pipelineOptions;

--- a/src/main/java/com/google/cloud/genomics/dataflow/pipelines/CountReads.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/pipelines/CountReads.java
@@ -95,6 +95,8 @@ public class CountReads {
 
   }
 
+  // Tip: Use the API explorer to test which fields to include in partial responses.
+  // https://developers.google.com/apis-explorer/#p/genomics/v1/genomics.reads.stream?fields=alignments(alignedSequence%252Cid)&_h=2&resource=%257B%250A++%2522readGroupSetId%2522%253A+%2522CMvnhpKTFhD3he72j4KZuyc%2522%252C%250A++%2522referenceName%2522%253A+%2522chr17%2522%252C%250A++%2522start%2522%253A+%252241196311%2522%252C%250A++%2522end%2522%253A+%252241196312%2522%250A%257D&
   private static final String READ_FIELDS = "alignments(alignment,id)";
   private static final Logger LOG = Logger.getLogger(CountReads.class.getName());
   private static Pipeline p;

--- a/src/main/java/com/google/cloud/genomics/dataflow/pipelines/IdentityByState.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/pipelines/IdentityByState.java
@@ -89,6 +89,8 @@ public class IdentityByState {
 
   }
 
+  // Tip: Use the API explorer to test which fields to include in partial responses.
+  // https://developers.google.com/apis-explorer/#p/genomics/v1/genomics.variants.stream?fields=variants(alternateBases%252Ccalls(callSetName%252Cgenotype)%252CreferenceBases)&_h=3&resource=%257B%250A++%2522variantSetId%2522%253A+%25223049512673186936334%2522%252C%250A++%2522referenceName%2522%253A+%2522chr17%2522%252C%250A++%2522start%2522%253A+%252241196311%2522%252C%250A++%2522end%2522%253A+%252241196312%2522%252C%250A++%2522callSetIds%2522%253A+%250A++%255B%25223049512673186936334-0%2522%250A++%255D%250A%257D&
   private static final String VARIANT_FIELDS =
       "variants(alternateBases,calls(callSetName,genotype),end,referenceBases,start)";
 

--- a/src/main/java/com/google/cloud/genomics/dataflow/pipelines/IdentityByState.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/pipelines/IdentityByState.java
@@ -89,7 +89,8 @@ public class IdentityByState {
 
   }
 
-  private static final String VARIANT_FIELDS = "variants(start,calls(genotype,callSetName))";
+  private static final String VARIANT_FIELDS =
+      "variants(alternateBases,calls(callSetName,genotype),end,referenceBases,start)";
 
   public static void main(String[] args) throws Exception {
     // Register the options so that they show up via --help

--- a/src/main/java/com/google/cloud/genomics/dataflow/pipelines/VariantSimilarity.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/pipelines/VariantSimilarity.java
@@ -73,6 +73,8 @@ public class VariantSimilarity {
     }
   }
 
+  // Tip: Use the API explorer to test which fields to include in partial responses.
+  // https://developers.google.com/apis-explorer/#p/genomics/v1/genomics.variants.stream?fields=variants(alternateBases%252Ccalls(callSetName%252Cgenotype)%252CreferenceBases)&_h=3&resource=%257B%250A++%2522variantSetId%2522%253A+%25223049512673186936334%2522%252C%250A++%2522referenceName%2522%253A+%2522chr17%2522%252C%250A++%2522start%2522%253A+%252241196311%2522%252C%250A++%2522end%2522%253A+%252241196312%2522%252C%250A++%2522callSetIds%2522%253A+%250A++%255B%25223049512673186936334-0%2522%250A++%255D%250A%257D&
   private static final String VARIANT_FIELDS = "variants(start,calls(genotype,callSetName))";
 
   public static void main(String[] args) throws IOException, GeneralSecurityException {

--- a/src/main/java/com/google/cloud/genomics/dataflow/pipelines/VerifyBamId.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/pipelines/VerifyBamId.java
@@ -153,6 +153,8 @@ public class VerifyBamId {
    * String prefix used for sampling hash function
    */
   private static final String HASH_PREFIX = "";
+  // Tip: Use the API explorer to test which fields to include in partial responses.
+  // https://developers.google.com/apis-explorer/#p/genomics/v1/genomics.variants.stream?fields=variants(alternateBases%252Ccalls(callSetName%252Cgenotype)%252CreferenceBases)&_h=3&resource=%257B%250A++%2522variantSetId%2522%253A+%25223049512673186936334%2522%252C%250A++%2522referenceName%2522%253A+%2522chr17%2522%252C%250A++%2522start%2522%253A+%252241196311%2522%252C%250A++%2522end%2522%253A+%252241196312%2522%252C%250A++%2522callSetIds%2522%253A+%250A++%255B%25223049512673186936334-0%2522%250A++%255D%250A%257D&
   private static final String VARIANT_FIELDS = "variants(start,calls(genotype,callSetName))";
 
   /**

--- a/src/main/java/com/google/cloud/genomics/dataflow/readers/ReadGroupStreamer.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/readers/ReadGroupStreamer.java
@@ -46,8 +46,9 @@ public class ReadGroupStreamer extends PTransform<PCollection<String>, PCollecti
   /**
    * Create a streamer that can appropriately shard a potentially large number of ReadGroupSets.
    *
-   * Tip: Use the API explorer to test which fields to include in partial responses.
-   * https://developers.google.com/apis-explorer/#p/genomics/v1/genomics.reads.stream?fields=alignments(alignedSequence%252Cid)&_h=2&resource=%257B%250A++%2522readGroupSetId%2522%253A+%2522CMvnhpKTFhD3he72j4KZuyc%2522%252C%250A++%2522referenceName%2522%253A+%2522chr17%2522%252C%250A++%2522start%2522%253A+%252241196311%2522%252C%250A++%2522end%2522%253A+%252241196312%2522%250A%257D&
+   * Tip: Use the API explorer to test which fields to include in partial responses:
+   * <a href="https://developers.google.com/apis-explorer/#p/genomics/v1/genomics.reads.stream?fields=alignments(alignedSequence%252Cid)&_h=2&resource=%257B%250A++%2522readGroupSetId%2522%253A+%2522CMvnhpKTFhD3he72j4KZuyc%2522%252C%250A++%2522referenceName%2522%253A+%2522chr17%2522%252C%250A++%2522start%2522%253A+%252241196311%2522%252C%250A++%2522end%2522%253A+%252241196312%2522%250A%257D&">
+   * reads example</a>.
    *
    * @param auth The OfflineAuth to use for the request.
    * @param shardBoundary The shard boundary semantics to enforce.

--- a/src/main/java/com/google/cloud/genomics/dataflow/readers/ReadGroupStreamer.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/readers/ReadGroupStreamer.java
@@ -46,6 +46,9 @@ public class ReadGroupStreamer extends PTransform<PCollection<String>, PCollecti
   /**
    * Create a streamer that can appropriately shard a potentially large number of ReadGroupSets.
    *
+   * Tip: Use the API explorer to test which fields to include in partial responses.
+   * https://developers.google.com/apis-explorer/#p/genomics/v1/genomics.reads.stream?fields=alignments(alignedSequence%252Cid)&_h=2&resource=%257B%250A++%2522readGroupSetId%2522%253A+%2522CMvnhpKTFhD3he72j4KZuyc%2522%252C%250A++%2522referenceName%2522%253A+%2522chr17%2522%252C%250A++%2522start%2522%253A+%252241196311%2522%252C%250A++%2522end%2522%253A+%252241196312%2522%250A%257D&
+   *
    * @param auth The OfflineAuth to use for the request.
    * @param shardBoundary The shard boundary semantics to enforce.
    * @param fields Which fields to include in a partial response or null for all.

--- a/src/main/java/com/google/cloud/genomics/dataflow/readers/ReadStreamer.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/readers/ReadStreamer.java
@@ -47,6 +47,9 @@ PTransform<PCollection<StreamReadsRequest>, PCollection<Read>> {
   /**
    * Create a streamer that can enforce shard boundary semantics.
    *
+   * Tip: Use the API explorer to test which fields to include in partial responses.
+   * https://developers.google.com/apis-explorer/#p/genomics/v1/genomics.reads.stream?fields=alignments(alignedSequence%252Cid)&_h=2&resource=%257B%250A++%2522readGroupSetId%2522%253A+%2522CMvnhpKTFhD3he72j4KZuyc%2522%252C%250A++%2522referenceName%2522%253A+%2522chr17%2522%252C%250A++%2522start%2522%253A+%252241196311%2522%252C%250A++%2522end%2522%253A+%252241196312%2522%250A%257D&
+   *
    * @param auth The OfflineAuth to use for the request.
    * @param shardBoundary The shard boundary semantics to enforce.
    * @param fields Which fields to include in a partial response or null for all.

--- a/src/main/java/com/google/cloud/genomics/dataflow/readers/ReadStreamer.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/readers/ReadStreamer.java
@@ -47,8 +47,9 @@ PTransform<PCollection<StreamReadsRequest>, PCollection<Read>> {
   /**
    * Create a streamer that can enforce shard boundary semantics.
    *
-   * Tip: Use the API explorer to test which fields to include in partial responses.
-   * https://developers.google.com/apis-explorer/#p/genomics/v1/genomics.reads.stream?fields=alignments(alignedSequence%252Cid)&_h=2&resource=%257B%250A++%2522readGroupSetId%2522%253A+%2522CMvnhpKTFhD3he72j4KZuyc%2522%252C%250A++%2522referenceName%2522%253A+%2522chr17%2522%252C%250A++%2522start%2522%253A+%252241196311%2522%252C%250A++%2522end%2522%253A+%252241196312%2522%250A%257D&
+   * Tip: Use the API explorer to test which fields to include in partial responses:
+   * <a href="https://developers.google.com/apis-explorer/#p/genomics/v1/genomics.reads.stream?fields=alignments(alignedSequence%252Cid)&_h=2&resource=%257B%250A++%2522readGroupSetId%2522%253A+%2522CMvnhpKTFhD3he72j4KZuyc%2522%252C%250A++%2522referenceName%2522%253A+%2522chr17%2522%252C%250A++%2522start%2522%253A+%252241196311%2522%252C%250A++%2522end%2522%253A+%252241196312%2522%250A%257D&">
+   * reads example</a>.
    *
    * @param auth The OfflineAuth to use for the request.
    * @param shardBoundary The shard boundary semantics to enforce.

--- a/src/main/java/com/google/cloud/genomics/dataflow/readers/VariantStreamer.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/readers/VariantStreamer.java
@@ -52,8 +52,9 @@ PTransform<PCollection<StreamVariantsRequest>, PCollection<Variant>> {
   /**
    * Create a streamer that can enforce shard boundary semantics.
    *
-   * Tip: Use the API explorer to test which fields to include in partial responses.
-   * https://developers.google.com/apis-explorer/#p/genomics/v1/genomics.variants.stream?fields=variants(alternateBases%252Ccalls(callSetName%252Cgenotype)%252CreferenceBases)&_h=3&resource=%257B%250A++%2522variantSetId%2522%253A+%25223049512673186936334%2522%252C%250A++%2522referenceName%2522%253A+%2522chr17%2522%252C%250A++%2522start%2522%253A+%252241196311%2522%252C%250A++%2522end%2522%253A+%252241196312%2522%252C%250A++%2522callSetIds%2522%253A+%250A++%255B%25223049512673186936334-0%2522%250A++%255D%250A%257D&
+   * Tip: Use the API explorer to test which fields to include in partial responses:
+   * <a href="https://developers.google.com/apis-explorer/#p/genomics/v1/genomics.variants.stream?fields=variants(alternateBases%252Ccalls(callSetName%252Cgenotype)%252CreferenceBases)&_h=3&resource=%257B%250A++%2522variantSetId%2522%253A+%25223049512673186936334%2522%252C%250A++%2522referenceName%2522%253A+%2522chr17%2522%252C%250A++%2522start%2522%253A+%252241196311%2522%252C%250A++%2522end%2522%253A+%252241196312%2522%252C%250A++%2522callSetIds%2522%253A+%250A++%255B%25223049512673186936334-0%2522%250A++%255D%250A%257D&">
+   * variants example</a>.
    *
    * @param auth The OfflineAuth to use for the request.
    * @param shardBoundary The shard boundary semantics to enforce.

--- a/src/main/java/com/google/cloud/genomics/dataflow/readers/VariantStreamer.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/readers/VariantStreamer.java
@@ -52,6 +52,9 @@ PTransform<PCollection<StreamVariantsRequest>, PCollection<Variant>> {
   /**
    * Create a streamer that can enforce shard boundary semantics.
    *
+   * Tip: Use the API explorer to test which fields to include in partial responses.
+   * https://developers.google.com/apis-explorer/#p/genomics/v1/genomics.variants.stream?fields=variants(alternateBases%252Ccalls(callSetName%252Cgenotype)%252CreferenceBases)&_h=3&resource=%257B%250A++%2522variantSetId%2522%253A+%25223049512673186936334%2522%252C%250A++%2522referenceName%2522%253A+%2522chr17%2522%252C%250A++%2522start%2522%253A+%252241196311%2522%252C%250A++%2522end%2522%253A+%252241196312%2522%252C%250A++%2522callSetIds%2522%253A+%250A++%255B%25223049512673186936334-0%2522%250A++%255D%250A%257D&
+   *
    * @param auth The OfflineAuth to use for the request.
    * @param shardBoundary The shard boundary semantics to enforce.
    * @param fields Which fields to include in a partial response or null for all.


### PR DESCRIPTION
Fixes for bugs found per integration test results. (It appears that my local override for utils-java was misconfigured last time I ran these :-(

I manually re-ran Calculate Coverage and checked the results.  It and the new DeleteVariants pipelines are the only ones without integration tests right now.