### PR TITLE
VerifyBamId update

### DIFF
--- a/src/main/java/com/google/cloud/genomics/dataflow/model/AlleleFreq.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/model/AlleleFreq.java
@@ -58,21 +58,21 @@ public class AlleleFreq {
     this.refFreq = refFreq;
   }
 	
-	@Override
-	public int hashCode() {
-		return Objects.hash(refBases, altBases, refFreq);
-	}
+  @Override
+  public int hashCode() {
+    return Objects.hash(refBases, altBases, refFreq);
+  }
 
-	@Override
-	public boolean equals(Object o) {
-		if (!(o instanceof AlleleFreq)) {
-			return false;
-		}
-		AlleleFreq otherAlleleFreq = (AlleleFreq) o;
-		return Objects.equals(refBases, otherAlleleFreq.getRefBases())
-			&& (refFreq == otherAlleleFreq.getRefFreq())
-			&& altBases.containsAll(otherAlleleFreq.getAltBases());
-	}
+  @Override
+  public boolean equals(Object o) {
+    if (!(o instanceof AlleleFreq)) {
+      return false;
+    }
+    AlleleFreq otherAlleleFreq = (AlleleFreq) o;
+    return Objects.equals(refBases, otherAlleleFreq.getRefBases())
+      && (refFreq == otherAlleleFreq.getRefFreq())
+      && altBases.containsAll(otherAlleleFreq.getAltBases());
+  }
 
   /* (non-Javadoc)
    * @see java.lang.Object#toString()

--- a/src/main/java/com/google/cloud/genomics/dataflow/model/AlleleFreq.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/model/AlleleFreq.java
@@ -74,7 +74,7 @@ public class AlleleFreq {
 			&& altBases.containsAll(otherAlleleFreq.getAltBases());
 	}
 
-	/* (non-Javadoc)
+  /* (non-Javadoc)
    * @see java.lang.Object#toString()
    */
   @Override

--- a/src/main/java/com/google/cloud/genomics/dataflow/model/AlleleFreq.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/model/AlleleFreq.java
@@ -15,18 +15,17 @@
  */
 package com.google.cloud.genomics.dataflow.model;
 
-import com.google.api.client.json.GenericJson;
 import com.google.cloud.dataflow.sdk.coders.DefaultCoder;
-import com.google.cloud.genomics.dataflow.coders.GenericJsonCoder;
-
+import com.google.cloud.dataflow.sdk.coders.AvroCoder;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Contains frequency for a set of alleles for a single position on a single chromosome.
  * Used in VerifyBamId.
  */
-@DefaultCoder(GenericJsonCoder.class)
-public class AlleleFreq extends GenericJson {
+@DefaultCoder(AvroCoder.class)
+public class AlleleFreq {
   // Strings of length 1 of one of the following bases: ['A', 'C', 'T', 'G'].
   private String refBases;
   // List of length 1 of a String of length 1 of one of the following bases: ['A', 'C', 'T', 'G'].
@@ -58,8 +57,24 @@ public class AlleleFreq extends GenericJson {
   public void setRefFreq(double refFreq) {
     this.refFreq = refFreq;
   }
+	
+	@Override
+	public int hashCode() {
+		return Objects.hash(refBases, altBases, refFreq);
+	}
 
-  /* (non-Javadoc)
+	@Override
+	public boolean equals(Object o) {
+		if (!(o instanceof AlleleFreq)) {
+			return false;
+		}
+		AlleleFreq otherAlleleFreq = (AlleleFreq) o;
+		return Objects.equals(refBases, otherAlleleFreq.getRefBases())
+			&& (refFreq == otherAlleleFreq.getRefFreq())
+			&& altBases.containsAll(otherAlleleFreq.getAltBases());
+	}
+
+	/* (non-Javadoc)
    * @see java.lang.Object#toString()
    */
   @Override

--- a/src/main/java/com/google/cloud/genomics/dataflow/model/ReadBaseQuality.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/model/ReadBaseQuality.java
@@ -15,17 +15,16 @@
  */
 package com.google.cloud.genomics.dataflow.model;
 
-import com.google.api.client.json.GenericJson;
+import com.google.cloud.dataflow.sdk.coders.AvroCoder;
 import com.google.cloud.dataflow.sdk.coders.DefaultCoder;
-import com.google.cloud.genomics.dataflow.coders.GenericJsonCoder;
 
 import java.util.Objects;
 
 /**
  * Data on a single base in a read, used for pileup.
  */
-@DefaultCoder(GenericJsonCoder.class)
-public class ReadBaseQuality extends GenericJson {
+@DefaultCoder(AvroCoder.class)
+public class ReadBaseQuality {
 
   private String base;
   private int quality;

--- a/src/main/java/com/google/cloud/genomics/dataflow/pipelines/VerifyBamId.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/pipelines/VerifyBamId.java
@@ -131,7 +131,7 @@ public class VerifyBamId {
         + "  Defaults to the 1,000 Genomes phase 1 VariantSet with id " + DEFAULT_VARIANTSET + ".")
     @Default.String(DEFAULT_VARIANTSET)
     String getVariantSetId();
-		void setVariantSetId(String variantSetId);
+    void setVariantSetId(String variantSetId);
 
     @Description("The minimum allele frequency to use in analysis.  Defaults to 0.01.")
     @Default.Double(0.01)
@@ -210,7 +210,7 @@ public class VerifyBamId {
         .apply(Create.of(rgsIds))
         .apply(ParDo.of(new CheckMatchingReferenceSet(referenceSetId, auth)))
         .apply(new ReadGroupStreamer(auth, ShardBoundary.Requirement.STRICT, null,
-                                   SexChromosomeFilter.INCLUDE_XY));
+                                     SexChromosomeFilter.INCLUDE_XY));
 
     /*
     TODO:  We can reduce the number of requests needed to be created by doing the following:

--- a/src/main/java/com/google/cloud/genomics/dataflow/pipelines/VerifyBamId.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/pipelines/VerifyBamId.java
@@ -94,7 +94,7 @@ import java.util.Vector;
  * http://www.sciencedirect.com/science/article/pii/S0002929712004788
  */
 public class VerifyBamId {
-	private static final Logger LOG = Logger.getLogger(VerifyBamId.class.getName());
+  private static final Logger LOG = Logger.getLogger(VerifyBamId.class.getName());
   /**
    * Options required to run this pipeline.
    */
@@ -211,9 +211,9 @@ public class VerifyBamId {
     // Reads in Reads.
     PCollection<Read> reads = p.begin()
       .apply(Create.of(rgsIds))
-			.apply(ParDo.of(new CheckMatchingReferenceSet(referenceSetId, auth)))
-			.apply(new ReadGroupStreamer(auth, ShardBoundary.Requirement.STRICT, null, SexChromosomeFilter.INCLUDE_XY));
-	
+      .apply(ParDo.of(new CheckMatchingReferenceSet(referenceSetId, auth)))
+      .apply(new ReadGroupStreamer(auth, ShardBoundary.Requirement.STRICT, null, SexChromosomeFilter.INCLUDE_XY));
+
     /*
     TODO:  We can reduce the number of requests needed to be created by doing the following:
     1. Stream the Variants first (rather than concurrently with the Reads).  Select a subset of
@@ -243,14 +243,13 @@ public class VerifyBamId {
 
     // Calculates the contamination estimate based on the resulting Map above.
     PCollection<String> result = p.begin()
-			.apply(Create.of(""))
+      .apply(Create.of(""))
       .apply(ParDo.of(new Maximizer(view)).withSideInputs(view));
-		
+
     // Writes the result to the given output location in Cloud Storage.
     result.apply(TextIO.Write.to(pipelineOptions.getOutput()).named("WriteOutput").withoutSharding());
 
     p.run();
-
   }
 
   /**

--- a/src/main/java/com/google/cloud/genomics/dataflow/pipelines/VerifyBamId.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/pipelines/VerifyBamId.java
@@ -488,7 +488,7 @@ public class VerifyBamId {
     // Grid search step size
     private static final double GRID_STEP = 0.001;
 
-	  public Maximizer(PCollectionView<Map<Position, ReadCounts>> view) {
+    public Maximizer(PCollectionView<Map<Position, ReadCounts>> view) {
       this.view = view;
     }
 

--- a/src/main/java/com/google/cloud/genomics/dataflow/pipelines/VerifyBamId.java
+++ b/src/main/java/com/google/cloud/genomics/dataflow/pipelines/VerifyBamId.java
@@ -232,7 +232,6 @@ public class VerifyBamId {
     PCollection<Variant> variants = p.apply(Create.of(variantRequests))
     .apply(new VariantStreamer(auth, ShardBoundary.Requirement.STRICT, VARIANT_FIELDS));
 
-		// TODO(sergip): there are no refFreq elements returned by getFreq
     PCollection<KV<Position, AlleleFreq>> refFreq = getFreq(variants, pipelineOptions.getMinFrequency());
 
     PCollection<KV<Position, ReadCounts>> readCountsTable =

--- a/src/test/java/com/google/cloud/genomics/dataflow/pipelines/VerifyBamIdTest.java
+++ b/src/test/java/com/google/cloud/genomics/dataflow/pipelines/VerifyBamIdTest.java
@@ -57,7 +57,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-import java.util.logging.Logger;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -67,9 +66,7 @@ import com.google.cloud.dataflow.sdk.transforms.DoFn;
  * Tests for the VerifyBamId pipeline.
  */
 @RunWith(JUnit4.class)
-public class VerifyBamIdTest {
-	private static final Logger LOG = Logger.getLogger(VerifyBamId.class.getName());	
-
+public class VerifyBamIdTest {	
   @Test
   public void testSplitReads_singleMatchedBase() {
     DoFnTester<Read, KV<Position, ReadBaseQuality>> splitReads = DoFnTester.of(new SplitReads());
@@ -268,42 +265,39 @@ public class VerifyBamIdTest {
     Assert.assertTrue(filterFreq.apply(KV.of(pos, af)));
   }
 
-  private final Position position1
-    = Position.newBuilder()
+  private final Position position1 = Position.newBuilder()
       .setReferenceName("1")
       .setPosition(123L)
       .build();
-  private final Position position2
-    = Position.newBuilder()
+  private final Position position2 = Position.newBuilder()
       .setReferenceName("1")
       .setPosition(124L)
       .build();
-  private final Position position3
-    = Position.newBuilder()
+  private final Position position3 = Position.newBuilder()
       .setReferenceName("1")
       .setPosition(125L)
       .build();
-  private final Position position1chrPrefix
-  = Position.newBuilder()
+  private final Position position1chrPrefix = Position.newBuilder()
     .setReferenceName("chr1")
     .setPosition(123L)
     .build();
 
-	private final ReadCounts rc1;
-	{		rc1 = new ReadCounts();
-			rc1.setRefFreq(0.8);
-			rc1.addReadQualityCount(ReadQualityCount.Base.REF, 10, 1);
-	}
-
-	private final ReadCounts rc2;
-	{		rc2 = new ReadCounts();
-			rc2.setRefFreq(0.5);
-	}
-
-	private final ReadCounts rc3;
-	{		rc3 = new ReadCounts();
-			rc3.setRefFreq(0.6);
-	}
+  private final ReadCounts rc1;
+  {
+    rc1 = new ReadCounts();
+    rc1.setRefFreq(0.8);
+    rc1.addReadQualityCount(ReadQualityCount.Base.REF, 10, 1);
+  }
+  private final ReadCounts rc2;
+  {
+    rc2 = new ReadCounts();
+    rc2.setRefFreq(0.5);
+  }
+  private final ReadCounts rc3;
+  {
+    rc3 = new ReadCounts();
+    rc3.setRefFreq(0.6);
+  }
 
   private ImmutableList<KV<Position, AlleleFreq>> refCountList;
   {
@@ -353,12 +347,12 @@ public class VerifyBamIdTest {
     PCollection<KV<Position, ReadCounts>> result = joined.apply(
         ParDo.of(new PileupAndJoinReads(readCountsTag, refFreqTag)));
 		
-		KV<Position, ReadCounts> expectedResult1 = KV.of(position1, rc1);
-		KV<Position, ReadCounts> expectedResult2 = KV.of(position2, rc2);
-		KV<Position, ReadCounts> expectedResult3 = KV.of(position3, rc3);
+    KV<Position, ReadCounts> expectedResult1 = KV.of(position1, rc1);
+    KV<Position, ReadCounts> expectedResult2 = KV.of(position2, rc2);
+    KV<Position, ReadCounts> expectedResult3 = KV.of(position3, rc3);
 
     DataflowAssert.that(result).containsInAnyOrder(expectedResult1, expectedResult2, expectedResult3);
-		p.run();
+    p.run();
   }
 
   @Test
@@ -386,9 +380,9 @@ public class VerifyBamIdTest {
     PCollection<KV<Position, ReadCounts>> result = joined.apply(
         ParDo.of(new PileupAndJoinReads(readCountsTag, refFreqTag)));
 	
-		KV<Position, ReadCounts> expectedResult1 = KV.of(position1, rc1);
-		KV<Position, ReadCounts> expectedResult2 = KV.of(position2, rc2);
-		KV<Position, ReadCounts> expectedResult3 = KV.of(position3, rc3);
+    KV<Position, ReadCounts> expectedResult1 = KV.of(position1, rc1);
+    KV<Position, ReadCounts> expectedResult2 = KV.of(position2, rc2);
+    KV<Position, ReadCounts> expectedResult3 = KV.of(position3, rc3);
 
     DataflowAssert.that(result).containsInAnyOrder(expectedResult1, expectedResult2, expectedResult3);
     p.run();

--- a/src/test/java/com/google/cloud/genomics/dataflow/pipelines/VerifyBamIdTest.java
+++ b/src/test/java/com/google/cloud/genomics/dataflow/pipelines/VerifyBamIdTest.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
- * You may obtain ia copy of the License at
+ * You may obtain a copy of the License at
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *

--- a/src/test/java/com/google/cloud/genomics/dataflow/pipelines/VerifyBamIdTest.java
+++ b/src/test/java/com/google/cloud/genomics/dataflow/pipelines/VerifyBamIdTest.java
@@ -329,7 +329,7 @@ public class VerifyBamIdTest {
 
   @Test
   public void testPileupAndJoinReads() {
-		VerifyBamId.Options popts =
+    VerifyBamId.Options popts =
         PipelineOptionsFactory.create().as(VerifyBamId.Options.class);
     Pipeline p = TestPipeline.create(popts);
     p.getCoderRegistry().setFallbackCoderProvider(GenericJsonCoder.PROVIDER);
@@ -337,7 +337,7 @@ public class VerifyBamIdTest {
     final ReadBaseQuality srq = new ReadBaseQuality("A", 10);
     PCollection<KV<Position, ReadBaseQuality>> readCounts = p.apply(
         Create.of(KV.of(position1, srq)));
-		DataflowAssert.that(readCounts).containsInAnyOrder(KV.of(position1, srq));
+    DataflowAssert.that(readCounts).containsInAnyOrder(KV.of(position1, srq));
 
     PCollection<KV<Position, AlleleFreq>> refFreq = p.apply(Create.of(refCountList));
 


### PR DESCRIPTION
Pipeline was not working for a couple of reasons:

- AlleleFreq and ReadBaseQuality had a Coder that was not working (updated to AvroCoder).
- AlleleFreq had no numerical value populated but a string value.

Updated the tests (basically failing because ContainsInAnyOrder was expected all KV<Position, ReadCount> and not only one.